### PR TITLE
ensure id is set when adding custom attack patterns

### DIFF
--- a/unfetter-ctf-ingest/src/services/unfetter-poster-mongo.service.ts
+++ b/unfetter-ctf-ingest/src/services/unfetter-poster-mongo.service.ts
@@ -26,8 +26,10 @@ export class UnfetterPosterMongoService {
         const wrappedArr: WrappedStix[] = arr.map((el) => {
             const v4 = UUID.v4();
             const id = el.type + '-' + v4;
+            el.id = id;
             const wrapper: WrappedStix = {
                 _id: id,
+                id,
                 stix: Object.assign({}, el),
             };
             return wrapper;
@@ -46,5 +48,6 @@ export class UnfetterPosterMongoService {
 
 interface WrappedStix {
     _id: string;
+    id: string;
     stix: Stix;
 }


### PR DESCRIPTION
supports unfetter-discover/unfetter#575

## To test
1. ingest a kill chain w/ attack patterns
```
  cd unfetter-store/unfetter-ctf-ingest
  npm run ingest:attack-pattern -- -f test-data/attack-patterns/attack-patterns-sample.csv
```
2. open robomongo or mongo shell and list attack patterns for new chain
`  db.getCollection('stix').find({'stix.type': 'attack-pattern', 'stix.kill_chain_phases.kill_chain_name': 'kill-chain-sample' })`
