### PR TITLE
fix url, unfetter-discover/unfetter#553

### DIFF
--- a/unfetter-ctf-ingest/src/adapters/ctf-to-stix-adapter.ts
+++ b/unfetter-ctf-ingest/src/adapters/ctf-to-stix-adapter.ts
@@ -48,7 +48,7 @@ export class CtfToStixAdapter {
             //  so should I consider it an id or url?
             const externalRef = {
                 external_id: ctf.reportId,
-                external_url: ctf.reportId,
+                url: ctf.reportId,
                 source_name: sourceType,
                 description,
             };


### PR DESCRIPTION
fix the external reference url

## Test
```
cd unfetter-ctf-ingest
npm run lint
npm run build
npm test
```

Requires UI PR. https://github.com/unfetter-discover/unfetter-ui/pull/163

Add an report, give it a url, see the url in the threat report dashboard under reports.