### PR TITLE
Issue 692/navigate threat report

### DIFF
--- a/unfetter-discover-api/api/controllers/latest.js
+++ b/unfetter-discover-api/api/controllers/latest.js
@@ -1,0 +1,196 @@
+const mongoose = require('mongoose');
+const schema = mongoose.Schema({}, { strict: false });
+
+const callPromise = (query, req, res) => {
+    const aggregationModel = modelFactory();
+    Promise.resolve(aggregationModel.aggregate(query))
+        .then((results) => {
+            if (results) {
+                const requestedUrl = req.originalUrl;
+                return res.status(200).json({
+                    links: {
+                        self: requestedUrl,
+                    },
+                    data: results
+                });
+            }
+
+            return res.status(404).json({
+                message: `No stix objects found for type ${type} and creator ${id}`
+            });
+        })
+        .catch(err =>
+            res.status(500).json({
+                errors: [{
+                    status: 500,
+                    source: '',
+                    title: 'Error',
+                    code: '',
+                    detail: 'An unknown error has occurred.'
+                }]
+            })
+        );
+}
+
+/**
+  * @description fetch stix of given type for given creator id, sort base on last modified
+  */
+const getLatestByTypeAndCreatorId = (req, res) => {
+    res.header('Content-Type', 'application/vnd.api+json');
+    const id = req.swagger.params.id ? req.swagger.params.id.value : '';
+    const type = req.swagger.params.type ? req.swagger.params.type.value : '';
+
+    // aggregate pipeline
+    //  match on given user and given type
+    //  sort on last modified
+    const latestByTypeAndCreator = [
+        {
+            $match: {
+                'creator': id,
+                'stix.type': type
+            }
+        },
+        {
+            '$group':
+                {
+                    _id: '$stix.id',
+                    'id': { $push: '$stix.id' },
+                    'name': { $first: '$stix.name' },
+                    'type': { $first: '$stix.type' },
+                    'modified': { $max: '$stix.modified' },
+                    'create_by_ref': { $first: '$creator' }
+                }
+        },
+        {
+            $unwind: '$id'
+        },
+        {
+            $sort: {
+                'modified': -1
+            }
+        }
+    ];
+
+    callPromise(latestByTypeAndCreator, req, res);
+};
+
+/**
+ * @description fetch ids for given stix type, sort base on last modified
+ */
+const getLatestByType = (req, res) => {
+    const type = req.swagger.params.type ? req.swagger.params.type.value : '';
+    res.header('Content-Type', 'application/vnd.api+json');
+
+    // aggregate pipeline
+    //  match on type
+    //  sort on last modified
+    const latestByType = [
+        {
+            '$match': { 'stix.type': 'report' }
+        },
+        {
+            '$group':
+                {
+                    _id: '$stix.id',
+                    'id': { $push: '$stix.id' },
+                    'name': { $first: '$stix.name' },
+                    'type': { $first: '$stix.type' },
+                    'modified': { $max: '$stix.modified' },
+                    'create_by_ref': { $first: '$creator' }
+                }
+        },
+        {
+            $unwind: '$id'
+        },
+        {
+            '$sort':
+                { modified: -1 }
+        }
+    ];
+
+    callPromise(latestByType, req, res);
+};
+
+
+
+/**
+  * @description fetch stix of given type for given creator id, sort base on last modified
+  */
+const getLatestThreatReportByCreatorId = (req, res) => {
+    res.header('Content-Type', 'application/vnd.api+json');
+    const id = req.swagger.params.id ? req.swagger.params.id.value : '';
+
+    // aggregate pipeline
+    const latestByCreatorWithRollup = [
+        {
+            $match: {
+                'creator': id,
+                'stix.type': 'report'
+            }
+        },
+        ...threatReportAggregateGroupAndUnwind()
+    ];
+
+    callPromise(latestByCreatorWithRollup, req, res);
+};
+
+/**
+ * @description fetch ids for given stix type, sort base on last modified
+ */
+const getLatestThreatReport = (req, res) => {
+    const type = req.swagger.params.type ? req.swagger.params.type.value : '';
+    const rollupId = req.swagger.params.rollupId ? req.swagger.params.rollupId.value : '';
+    res.header('Content-Type', 'application/vnd.api+json');
+
+    // aggregate pipeline
+    const latestThreatReport = [
+        {
+            '$match': { 'stix.type': 'report' }
+        },
+        ...threatReportAggregateGroupAndUnwind()
+    ];
+
+    callPromise(latestThreatReport, req, res);
+};
+
+const threatReportAggregateGroupAndUnwind = () => {
+    // aggregate pipeline
+    // no match
+    // group on workproduct ids
+    // unwind the arrays
+    // sort on last modified
+    return [{
+        '$group':
+            {
+                '_id': '$metaProperties.work_products.id',
+                'workproductId': { $first: '$metaProperties.work_products.id' },
+                'reportIds': { $push: '$stix.id' },
+                'name': { $first: '$stix.name' },
+                'type': { $first: '$stix.type' },
+                'modified': { $max: '$stix.modified' },
+                'create_by_ref': { $first: '$creator' }
+            }
+    },
+    {
+        $unwind: '$_id'
+    },
+    {
+        $unwind: '$workproductId'
+    },
+    {
+        $sort: {
+            'modified': -1
+        }
+    }];
+}
+
+const modelFactory = () => {
+    return mongoose.model(`aggregations`, schema, 'stix');
+}
+
+module.exports = {
+    getLatestByTypeAndCreatorId,
+    getLatestByType,
+    getLatestThreatReport,
+    getLatestThreatReportByCreatorId,
+};

--- a/unfetter-discover-api/api/controllers/latest.js
+++ b/unfetter-discover-api/api/controllers/latest.js
@@ -5,18 +5,12 @@ const callPromise = (query, req, res) => {
     const aggregationModel = modelFactory();
     Promise.resolve(aggregationModel.aggregate(query))
         .then((results) => {
-            if (results) {
-                const requestedUrl = req.originalUrl;
-                return res.status(200).json({
-                    links: {
-                        self: requestedUrl,
-                    },
-                    data: results
-                });
-            }
-
-            return res.status(404).json({
-                message: `No stix objects found for type ${type} and creator ${id}`
+            const requestedUrl = req.originalUrl;
+            return res.status(200).json({
+                links: {
+                    self: requestedUrl,
+                },
+                data: results
             });
         })
         .catch(err =>
@@ -117,8 +111,8 @@ const getLatestByType = (req, res) => {
   * @description fetch stix of given type for given creator id, sort base on last modified
   */
 const getLatestThreatReportByCreatorId = (req, res) => {
-    res.header('Content-Type', 'application/vnd.api+json');
     const id = req.swagger.params.id ? req.swagger.params.id.value : '';
+    res.header('Content-Type', 'application/vnd.api+json');
 
     // aggregate pipeline
     const latestByCreatorWithRollup = [

--- a/unfetter-discover-api/api/controllers/shared/basecontroller.js
+++ b/unfetter-discover-api/api/controllers/shared/basecontroller.js
@@ -315,7 +315,7 @@ module.exports = class BaseController {
                                 console.log('Unable to find identity, cannot publish to organization');
                             } else {
                                 const identityObj = identityResult.toObject();
-                                if(obj.stix.type === 'indicator') {
+                                if (obj.stix.type === 'indicator') {
                                     publish.notifyOrg(req.user._id, obj.stix.created_by_ref, 'STIX', `New STIX by ${identityObj.stix.name}`, `New ${newDocument.stix.type}: ${newDocument.stix.name}`, `/indicator-sharing/single/${newDocument._id}`);
                                 } else {
                                     publish.notifyOrg(req.user._id, obj.stix.created_by_ref, 'STIX', `New STIX by ${identityObj.stix.name}`, `New ${newDocument.stix.type}: ${newDocument.stix.name}`);
@@ -335,7 +335,7 @@ module.exports = class BaseController {
                     if (resObj.metaProperties) {
                         returnObj.metaProperties = resObj.metaProperties;
                     }
-                    
+
                     const convertedResult = jsonApiConverter.convertJsonToJsonApi([
                         returnObj
                     ], type, requestedUrl);
@@ -452,4 +452,6 @@ module.exports = class BaseController {
             });
         });
     }
+
+ 
 }

--- a/unfetter-discover-api/api/controllers/x_unfetter_assessments.js
+++ b/unfetter-discover-api/api/controllers/x_unfetter_assessments.js
@@ -833,37 +833,11 @@ const latestAssessmentsByCreatorId = (req, res) => {
     }
   ];
 
-  Promise.resolve(aggregationModel.aggregate(latestAssessmentsByCreatorId))
-    .then((results) => {
-      if (results) {
-        const requestedUrl = apiRoot + req.originalUrl;
-        return res.status(200).json({
-          links: {
-            self: requestedUrl,
-          },
-          data: results
-        });
-      }
-
-      return res.status(404).json({
-        message: `No assessments found for creator ${id}`
-      });
-    })
-    .catch(err =>
-      res.status(500).json({
-        errors: [{
-          status: 500,
-          source: '',
-          title: 'Error',
-          code: '',
-          detail: 'An unknown error has occurred.'
-        }]
-      })
-    );
+  latestAssessmentPromise(latestAssessmentsByCreatorId, req, res);
 };
 
 /**
- * @description fetch assessments for given creator id, sort base on last modified
+ * @description fetch assessments across the system, sort base on last modified
  */
 const latestAssessments = (req, res) => {
   const id = req.swagger.params.id ? req.swagger.params.id.value : '';
@@ -899,34 +873,33 @@ const latestAssessments = (req, res) => {
     }
   ];
 
-  Promise.resolve(aggregationModel.aggregate(latestAssessments))
-    .then((results) => {
-      if (results) {
-        const requestedUrl = apiRoot + req.originalUrl;
-        return res.status(200).json({
-          links: {
-            self: requestedUrl,
-          },
-          data: results
-        });
-      }
-
-      return res.status(404).json({
-        message: `No assessments found!`
-      });
-    })
-    .catch(err =>
-      res.status(500).json({
-        errors: [{
-          status: 500,
-          source: '',
-          title: 'Error',
-          code: '',
-          detail: 'An unknown error has occurred.'
-        }]
-      })
-    );
+  latestAssessmentPromise(latestAssessments, req, res);
 };
+
+const latestAssessmentPromise = (query, req, res) => {
+  const aggregationModel = modelFactory();
+  Promise.resolve(aggregationModel.aggregate(query))
+      .then((results) => {
+          const requestedUrl = req.originalUrl;
+          return res.status(200).json({
+              links: {
+                  self: requestedUrl,
+              },
+              data: results
+          });
+      })
+      .catch(err =>
+          res.status(500).json({
+              errors: [{
+                  status: 500,
+                  source: '',
+                  title: 'Error',
+                  code: '',
+                  detail: 'An unknown error has occurred.'
+              }]
+          })
+      );
+}
 
 module.exports = {
   get: controller.get(),

--- a/unfetter-discover-api/api/controllers/x_unfetter_assessments.js
+++ b/unfetter-discover-api/api/controllers/x_unfetter_assessments.js
@@ -798,7 +798,7 @@ const updateAnswerByAssessedObject = controller.getByIdCb((err, result, req, res
 /**
  * @description fetch assessments for given creator id, sort base on last modified
  */
-const latestAssessmentsByCreatorId = function killChain(req, res) {
+const latestAssessmentsByCreatorId = (req, res) => {
   const id = req.swagger.params.creatorId ? req.swagger.params.creatorId.value : '';
 
   // aggregate pipeline
@@ -865,7 +865,7 @@ const latestAssessmentsByCreatorId = function killChain(req, res) {
 /**
  * @description fetch assessments for given creator id, sort base on last modified
  */
-const latestAssessments = function killChain(req, res) {
+const latestAssessments = (req, res) => {
   const id = req.swagger.params.id ? req.swagger.params.id.value : '';
 
   // aggregate pipeline

--- a/unfetter-discover-api/api/controllers/x_unfetter_assessments.js
+++ b/unfetter-discover-api/api/controllers/x_unfetter_assessments.js
@@ -877,7 +877,6 @@ const latestAssessments = (req, res) => {
 };
 
 const latestAssessmentPromise = (query, req, res) => {
-  const aggregationModel = modelFactory();
   Promise.resolve(aggregationModel.aggregate(query))
       .then((results) => {
           const requestedUrl = req.originalUrl;

--- a/unfetter-discover-api/api/swagger/paths/index.yaml
+++ b/unfetter-discover-api/api/swagger/paths/index.yaml
@@ -138,3 +138,12 @@
   $ref: ./config/config.yaml
 /config/{id}:
   $ref: ./config/config_by_id.yaml
+
+/latest/threat-reports:
+  $ref: ./latest/latest-threat-report.yaml
+/latest/threat-reports/creator/{id}:
+  $ref: ./latest/latest-threat-report-by-id.yaml
+/latest/type/{type}:
+  $ref: ./latest/latest-by-type.yaml
+/latest/type/{type}/creator/{id}:
+  $ref: ./latest/latest-by-type-and-id.yaml

--- a/unfetter-discover-api/api/swagger/paths/latest/latest-by-type-and-id.yaml
+++ b/unfetter-discover-api/api/swagger/paths/latest/latest-by-type-and-id.yaml
@@ -1,0 +1,29 @@
+x-swagger-router-controller: latest
+get:
+  tags:
+  - STIX-Unfetter
+  - Ids sort by modified
+  description: Find all Ids of stix type given sorted by last modified
+  operationId: getLatestByTypeAndCreatorId
+  parameters:
+  - name: type
+    in: path
+    description: stix type
+    type: string
+    required: true
+  - name: id
+    in: path
+    description: stix type
+    type: string
+    required: true
+  produces: 
+  - application/vnd.api+json
+  responses:
+    "200":
+      description: Success
+      schema:
+        type: object     
+    default:
+      description: Error
+      schema:
+        $ref: "#/definitions/DetailedErrorResponse"

--- a/unfetter-discover-api/api/swagger/paths/latest/latest-by-type.yaml
+++ b/unfetter-discover-api/api/swagger/paths/latest/latest-by-type.yaml
@@ -1,0 +1,25 @@
+x-swagger-router-controller: latest
+get:
+  tags:
+  - STIX-Unfetter
+  - Ids sort by modified
+  description: Find all Ids of stix type given sorted by last modified
+  operationId: getLatestByType
+  parameters:
+  - name: type
+    in: path
+    description: stix type
+    type: string
+    required: true
+    format: JSON
+  produces: 
+  - application/vnd.api+json
+  responses:
+    "200":
+      description: Success
+      schema:
+        type: object     
+    default:
+      description: Error
+      schema:
+        type: object 

--- a/unfetter-discover-api/api/swagger/paths/latest/latest-threat-report-by-id.yaml
+++ b/unfetter-discover-api/api/swagger/paths/latest/latest-threat-report-by-id.yaml
@@ -1,0 +1,24 @@
+x-swagger-router-controller: latest
+get:
+  tags:
+  - STIX-Unfetter
+  - Ids sort by modified
+  description: Find all Ids of stix type given sorted by last modified
+  operationId: getLatestThreatReportByCreatorId
+  parameters:
+  - name: id
+    in: path
+    description: stix type
+    type: string
+    required: true
+  produces: 
+  - application/vnd.api+json
+  responses:
+    "200":
+      description: Success
+      schema:
+        type: object     
+    default:
+      description: Error
+      schema:
+        $ref: "#/definitions/DetailedErrorResponse"

--- a/unfetter-discover-api/api/swagger/paths/latest/latest-threat-report.yaml
+++ b/unfetter-discover-api/api/swagger/paths/latest/latest-threat-report.yaml
@@ -1,0 +1,18 @@
+x-swagger-router-controller: latest
+get:
+  tags:
+  - STIX-Unfetter
+  - Ids sort by modified
+  description: Find all Ids of stix type given sorted by last modified
+  operationId: getLatestThreatReport
+  produces: 
+  - application/vnd.api+json
+  responses:
+    "200":
+      description: Success
+      schema:
+        type: object     
+    default:
+      description: Error
+      schema:
+        type: object


### PR DESCRIPTION
supports unfetter-discover/unfetter#692

#To Test
* pull this branch
* `cd unfetter-store/unfetter-discover-api && npm run test` (make sure your docker stack is up, as this will hit mongo
* If you have a curl or postman tool setup hit these urls,
  * https://localhost/api/latest/threat-reports/creator/5a2967a0d1c5eb004223a448
  * https://localhost/api/latest/threat-reports
The above will need these headers, with your Bearer token added
```
[{"key":"Authorization","value":"Bearer <Bearer token here>","description":""},{"key":"Content-Type","value":"application/json","description":""},{"key":"Accept","value":"application/json","description":""}]
```