### PR TITLE
Issue 711/ctf docker build

### DIFF
--- a/unfetter-ctf-ingest/Dockerfile
+++ b/unfetter-ctf-ingest/Dockerfile
@@ -18,6 +18,9 @@ RUN $WORKING_DIRECTORY/set-npm-repo.sh
 # COPY package-lock.json $WORKING_DIRECTORY
 COPY package.json $WORKING_DIRECTORY
 
+RUN apk update && \
+    apk add git
+
 # The NPM package depends on TAR package, which has a test directory with an encrypted tgz file, that gets blocked by some antivirus scanners. Removing it.
 RUN npm --loglevel error install && \
     find / -name "cb-never*.tgz" -delete && \

--- a/unfetter-ctf-ingest/package.json
+++ b/unfetter-ctf-ingest/package.json
@@ -66,6 +66,6 @@
     "ts-node": "^4.1.0",
     "tslint": "^5.8.0",
     "typedoc": "^0.9.0",
-    "typescript": "^2.6.1"
+    "typescript": "~2.6.2"
   }
 }

--- a/unfetter-ctf-ingest/src/models/ctf.ts
+++ b/unfetter-ctf-ingest/src/models/ctf.ts
@@ -4,7 +4,7 @@ export class Ctf {
     public sourceType = '';
     public alaStage = '';
     public afaObjective = '';
-    public afaAction= '';
+    public afaAction = '';
     public description = '';
     public actionParagraph = '';
     public actionClassification = '';


### PR DESCRIPTION
fixes unfetter-discover/unfetter#711

# To Test
* Pull this PR
* docker stop and remove all processes `docker stop $(docker ps -qa) && docker rm -f $(docker ps -qa);`
* docker remove image ctf `docker rmi -f <ctf image id>`
* bring unfetter back up `cd $HOME/git-ws/unfetter-discover/unfetter && docker-compose -f docker-compose.development.yml up` (use your path)
* verify import reports button works (in the create workproduct page) use this file as a sample `test-data/ctf-sample.csv`