### PR TITLE
Remove spaces in example text to avoid bad quote conversion

### DIFF
--- a/unfetter-discover-api/api/swagger/paths/attack_patterns/attack_patterns.yaml
+++ b/unfetter-discover-api/api/swagger/paths/attack_patterns/attack_patterns.yaml
@@ -10,12 +10,12 @@ get:
   parameters:
     - name: filter
       in: query
-      description: 'Ex: { "name": "AppInit DLLs" }'
+      description: 'Ex: {"stix.name":"AppInit DLLs"}'
       required: false
       type: string
     - name: sort
       in: query
-      description: 'Ex: { "name": "1" } or { "name": "-1"}'
+      description: 'Ex: {"stix.name":"1"} or {"stix.name":"-1"}'
       required: false
       type: string
     - name: limit
@@ -38,7 +38,7 @@ get:
       description: boolean to include extended meta properties
     - name: project
       in: query
-      description: 'Ex: { "name": 1 } or { "name": 0}'
+      description: 'Ex: {"stix.created_by_ref":1} or {"stix.created_by_ref":0}'
       required: false
       type: string
   responses:

--- a/unfetter-discover-api/api/swagger/paths/campaigns/campaigns.yaml
+++ b/unfetter-discover-api/api/swagger/paths/campaigns/campaigns.yaml
@@ -10,12 +10,12 @@ get:
   parameters:
     - name: filter
       in: query
-      description: 'Ex: { "name": "Green Group Attacks Against Finance" }'
+      description: 'Ex: {"stix.name":"Green Group Attacks Against Finance"}'
       required: false
       type: string
     - name: sort
       in: query
-      description: 'Ex: { "name": "1" } or { "name": "-1"}'
+      description: 'Ex: {"stix.name":"1"} or {"stix.name":"-1"}'
       required: false
       type: string
     - name: limit
@@ -38,7 +38,7 @@ get:
       description: boolean to include extended meta properties
     - name: project
       in: query
-      description: 'Ex: { "name": 1 } or { "name": 0}'
+      description: 'Ex: {"stix.created_by_ref":1} or {"stix.created_by_ref":0}'
       required: false
       type: string
   responses:

--- a/unfetter-discover-api/api/swagger/paths/config/config.yaml
+++ b/unfetter-discover-api/api/swagger/paths/config/config.yaml
@@ -9,12 +9,12 @@ get:
   parameters:
     - name: filter
       in: query
-      description: 'Ex: { "name": "Cryptolocker" }'
+      description: 'Ex: {"configKey":"killChains"}'
       required: false
       type: string
     - name: sort
       in: query
-      description: 'Ex: { "name": "1" } or { "name": "-1"}'
+      description: 'Ex: {"configKey":"1"} or {"configKey":"-1"}'
       required: false
       type: string
     - name: limit

--- a/unfetter-discover-api/api/swagger/paths/course-of-actions/course-of-actions.yaml
+++ b/unfetter-discover-api/api/swagger/paths/course-of-actions/course-of-actions.yaml
@@ -10,12 +10,12 @@ get:
   parameters:
     - name: filter
       in: query
-      description: 'Ex: { "name": "Add TCP port 80 Filter Rule" }'
+      description: 'Ex: {"stix.name":"Add TCP port 80 Filter Rule"}'
       required: false
       type: string
     - name: sort
       in: query
-      description: 'Ex: { "name": "1" } or { "name": "-1"}'
+      description: 'Ex: {"stix.name":"1"} or {"stix.name":"-1"}'
       required: false
       type: string
     - name: limit
@@ -38,7 +38,7 @@ get:
       description: boolean to include extended meta properties
     - name: project
       in: query
-      description: 'Ex: { "name": 1 } or { "name": 0}'
+      description: 'Ex: {"stix.created_by_ref":1} or {"stix.created_by_ref":0}'
       required: false
       type: string
   responses:

--- a/unfetter-discover-api/api/swagger/paths/identities/identities.yaml
+++ b/unfetter-discover-api/api/swagger/paths/identities/identities.yaml
@@ -10,12 +10,12 @@ get:
   parameters:
     - name: filter
       in: query
-      description: 'Ex: { "name": "John Smith" }'
+      description: 'Ex: {"stix.name":"John Smith"}'
       required: false
       type: string
     - name: sort
       in: query
-      description: 'Ex: { "name": "1" } or { "name": "-1"}'
+      description: 'Ex: {"stix.name":"1"} or {"stix.name":"-1"}'
       required: false
       type: string
     - name: limit
@@ -38,7 +38,7 @@ get:
       description: boolean to include extended meta properties
     - name: project
       in: query
-      description: 'Ex: { "name": 1 } or { "name": 0}'
+      description: 'Ex: {"stix.created_by_ref":1} or {"stix.created_by_ref":0}'
       required: false
       type: string
   responses:

--- a/unfetter-discover-api/api/swagger/paths/indicators/attack-patterns-by-indicator.yaml
+++ b/unfetter-discover-api/api/swagger/paths/indicators/attack-patterns-by-indicator.yaml
@@ -10,12 +10,12 @@ get:
   parameters:
     - name: filter
       in: query
-      description: 'Ex: { "name": "Cryptolocker" }'
+      description: 'Ex: {"stix.name":"Cryptolocker"}'
       required: false
       type: string
     - name: sort
       in: query
-      description: 'Ex: { "name": "1" } or { "name": "-1"}'
+      description: 'Ex: {"stix.name":"1"} or {"stix.name":"-1"}'
       required: false
       type: string
     - name: limit

--- a/unfetter-discover-api/api/swagger/paths/indicators/indicators.yaml
+++ b/unfetter-discover-api/api/swagger/paths/indicators/indicators.yaml
@@ -10,12 +10,12 @@ get:
   parameters:
     - name: filter
       in: query
-      description: 'Ex: { "name": "Poison Ivy Malware" }'
+      description: 'Ex: {"stix.name":"Poison Ivy Malware"}'
       required: false
       type: string
     - name: sort
       in: query
-      description: 'Ex: { "name": "1" } or { "name": "-1"}'
+      description: 'Ex: {"stix.name":"1"} or {"stix.name":"-1"}'
       required: false
       type: string
     - name: limit
@@ -38,7 +38,7 @@ get:
       description: boolean to include extended meta properties
     - name: project
       in: query
-      description: 'Ex: { "name": 1 } or { "name": 0}'
+      description: 'Ex: {"stix.created_by_ref":1} or {"stix.created_by_ref":0}'
       required: false
       type: string
   responses:

--- a/unfetter-discover-api/api/swagger/paths/intrusion_sets/intrusion_sets.yaml
+++ b/unfetter-discover-api/api/swagger/paths/intrusion_sets/intrusion_sets.yaml
@@ -10,12 +10,12 @@ get:
   parameters:
     - name: filter
       in: query
-      description: 'Ex: { "name": "Bobcat Breakin" }'
+      description: 'Ex: {"stix.name":"Bobcat Breakin"}'
       required: false
       type: string
     - name: sort
       in: query
-      description: 'Ex: { "name": "1" } or { "name": "-1"}'
+      description: 'Ex: {"stix.name":"1"} or {"stix.name":"-1"}'
       required: false
       type: string
     - name: limit
@@ -38,7 +38,7 @@ get:
       description: boolean to include extended meta properties
     - name: project
       in: query
-      description: 'Ex: { "name": 1 } or { "name": 0}'
+      description: 'Ex: {"stix.created_by_ref":1} or {"stix.created_by_ref":0}'
       required: false
       type: string
   responses:

--- a/unfetter-discover-api/api/swagger/paths/malwares/malwares.yaml
+++ b/unfetter-discover-api/api/swagger/paths/malwares/malwares.yaml
@@ -10,12 +10,12 @@ get:
   parameters:
     - name: filter
       in: query
-      description: 'Ex: { "name": "Cryptolocker" }'
+      description: 'Ex: {"stix.name":"Cryptolocker"}'
       required: false
       type: string
     - name: sort
       in: query
-      description: 'Ex: { "name": "1" } or { "name": "-1"}'
+      description: 'Ex: {"stix.name":"1"} or {"stix.name":"-1"}'
       required: false
       type: string
     - name: limit
@@ -38,7 +38,7 @@ get:
       description: boolean to include extended meta properties
     - name: project
       in: query
-      description: 'Ex: { "name": 1 } or { "name": 0}'
+      description: 'Ex: {"stix.created_by_ref":1} or {"stix.created_by_ref":0}'
       required: false
       type: string
   responses:

--- a/unfetter-discover-api/api/swagger/paths/marking_definitions/marking_definitions.yaml
+++ b/unfetter-discover-api/api/swagger/paths/marking_definitions/marking_definitions.yaml
@@ -10,12 +10,12 @@ get:
   parameters:
     - name: filter
       in: query
-      description: 'Ex: { "definition_type": "statement" }'
+      description: 'Ex: {"stix.definition_type":"statement"}'
       required: false
       type: string
     - name: sort
       in: query
-      description: 'Ex: { "definition_type": "1" } or { "definition_type": "-1"}'
+      description: 'Ex: {"stix.definition_type":"1"} or {"stix.definition_type":"-1"}'
       required: false
       type: string
     - name: limit
@@ -38,7 +38,7 @@ get:
       description: boolean to include extended meta properties
     - name: project
       in: query
-      description: 'Ex: { "name": 1 } or { "name": 0}'
+      description: 'Ex: {"stix.created_by_ref":1} or {"stix.created_by_ref":0}'
       required: false
       type: string
   responses:

--- a/unfetter-discover-api/api/swagger/paths/multiples/multiples.yaml
+++ b/unfetter-discover-api/api/swagger/paths/multiples/multiples.yaml
@@ -10,12 +10,12 @@ get:
   parameters:
     - name: filter
       in: query
-      description: 'Ex: { "name": "Cryptolocker" }'
+      description: 'Ex: {"stix.name":"Cryptolocker"}'
       required: false
       type: string
     - name: sort
       in: query
-      description: 'Ex: { "name": "1" } or { "name": "-1"}'
+      description: 'Ex: {"stix.name":"1"} or {"stix.name":"-1"}'
       required: false
       type: string
     - name: limit
@@ -38,7 +38,7 @@ get:
       description: boolean to include extended meta properties
     - name: project
       in: query
-      description: 'Ex: { "name": 1 } or { "name": 0}'
+      description: 'Ex: {"stix.created_by_ref":1} or {"stix.created_by_ref":0}'
       required: false
       type: string
   responses:

--- a/unfetter-discover-api/api/swagger/paths/observed_data/observed_data.yaml
+++ b/unfetter-discover-api/api/swagger/paths/observed_data/observed_data.yaml
@@ -10,12 +10,12 @@ get:
   parameters:
     - name: filter
       in: query
-      description: 'Ex: { "number_observed": 50 }'
+      description: 'Ex: {"stix.number_observed":50}'
       required: false
       type: string
     - name: sort
       in: query
-      description: 'Ex: { "number_observed": "1" } or { "number_observed": "-1"}'
+      description: 'Ex: {"stix.number_observed":"1"} or {"stix.number_observed":"-1"}'
       required: false
       type: string
     - name: limit
@@ -38,7 +38,7 @@ get:
       description: boolean to include extended meta properties
     - name: project
       in: query
-      description: 'Ex: { "name": 1 } or { "name": 0}'
+      description: 'Ex: {"stix.created_by_ref":1} or {"stix.created_by_ref":0}'
       required: false
       type: string
   responses:

--- a/unfetter-discover-api/api/swagger/paths/relationships/relationships.yaml
+++ b/unfetter-discover-api/api/swagger/paths/relationships/relationships.yaml
@@ -10,12 +10,12 @@ get:
   parameters:
     - name: filter
       in: query
-      description: 'Ex: { "relationship_type": "indicates" }'
+      description: 'Ex: {"stix.relationship_type":"indicates"}'
       required: false
       type: string
     - name: sort
       in: query
-      description: 'Ex: { "relationship_type": "1" } or { "relationship_type": "-1"}'
+      description: 'Ex: {"stix.relationship_type":"1"} or {"stix.relationship_type":"-1"}'
       required: false
       type: string
     - name: limit
@@ -38,7 +38,7 @@ get:
       description: boolean to include extended meta properties
     - name: project
       in: query
-      description: 'Ex: { "name": 1 } or { "name": 0}'
+      description: 'Ex: {"stix.created_by_ref":1} or {"stix.created_by_ref":0}'
       required: false
       type: string
   responses:

--- a/unfetter-discover-api/api/swagger/paths/reports/reports.yaml
+++ b/unfetter-discover-api/api/swagger/paths/reports/reports.yaml
@@ -10,12 +10,12 @@ get:
   parameters:
     - name: filter
       in: query
-      description: 'Ex: { "name": "The Black Vine Cyberespionage Group" }'
+      description: 'Ex: {"stix.name":"The Black Vine Cyberespionage Group"}'
       required: false
       type: string
     - name: sort
       in: query
-      description: 'Ex: { "name": "1" } or { "name": "-1"}'
+      description: 'Ex: {"stix.name":"1"} or {"stix.name":"-1"}'
       required: false
       type: string
     - name: limit
@@ -38,7 +38,7 @@ get:
       description: boolean to include extended meta properties
     - name: project
       in: query
-      description: 'Ex: { "name": 1 } or { "name": 0}'
+      description: 'Ex: {"stix.created_by_ref":1} or {"stix.created_by_ref":0}'
       required: false
       type: string
   responses:

--- a/unfetter-discover-api/api/swagger/paths/sightings/sightings.yaml
+++ b/unfetter-discover-api/api/swagger/paths/sightings/sightings.yaml
@@ -10,12 +10,12 @@ get:
   parameters:
     - name: filter
       in: query
-      description: 'Ex: { "name": "The Black Vine Cyberespionage Group" }'
+      description: 'Ex: {"stix.count":"1"}'
       required: false
       type: string
     - name: sort
       in: query
-      description: 'Ex: { "name": "1" } or { "name": "-1"}'
+      description: 'Ex: {"stix.count":"1"} or {"stix.count":"-1"}'
       required: false
       type: string
     - name: limit
@@ -38,7 +38,7 @@ get:
       description: boolean to include extended meta properties
     - name: project
       in: query
-      description: 'Ex: { "name": 1 } or { "name": 0}'
+      description: 'Ex: {"stix.created_by_ref":1} or {"stix.created_by_ref":0}'
       required: false
       type: string
   responses:

--- a/unfetter-discover-api/api/swagger/paths/threat_actors/threat_actors.yaml
+++ b/unfetter-discover-api/api/swagger/paths/threat_actors/threat_actors.yaml
@@ -10,12 +10,12 @@ get:
   parameters:
     - name: filter
       in: query
-      description: 'Ex: { "name": "The Black Vine Cyberespionage Group" }'
+      description: 'Ex: {"stix.name":"The Black Vine Cyberespionage Group"}'
       required: false
       type: string
     - name: sort
       in: query
-      description: 'Ex: { "name": "1" } or { "name": "-1"}'
+      description: 'Ex: {"stix.name":"1"} or {"stix.name":"-1"}'
       required: false
       type: string
     - name: limit
@@ -38,7 +38,7 @@ get:
       description: boolean to include extended meta properties
     - name: project
       in: query
-      description: 'Ex: { "name": 1 } or { "name": 0}'
+      description: 'Ex: {"stix.created_by_ref":1} or {"stix.created_by_ref":0}'
       required: false
       type: string
   responses:

--- a/unfetter-discover-api/api/swagger/paths/tools/tools.yaml
+++ b/unfetter-discover-api/api/swagger/paths/tools/tools.yaml
@@ -10,12 +10,12 @@ get:
   parameters:
     - name: filter
       in: query
-      description: 'Ex: { "name": "The Black Vine Cyberespionage Group" }'
+      description: 'Ex: {"stix.name":"The Black Vine Cyberespionage Group"}'
       required: false
       type: string
     - name: sort
       in: query
-      description: 'Ex: { "name": "1" } or { "name": "-1"}'
+      description: 'Ex: {"stix.name":"1"} or {"stix.name":"-1"}'
       required: false
       type: string
     - name: limit
@@ -38,7 +38,7 @@ get:
       description: boolean to include extended meta properties
     - name: project
       in: query
-      description: 'Ex: { "name": 1 } or { "name": 0}'
+      description: 'Ex: {"stix.created_by_ref":1} or {"stix.created_by_ref":0}'
       required: false
       type: string
   responses:

--- a/unfetter-discover-api/api/swagger/paths/x_unfetter_assessments/assessments.yaml
+++ b/unfetter-discover-api/api/swagger/paths/x_unfetter_assessments/assessments.yaml
@@ -9,12 +9,12 @@ get:
   parameters:
     - name: filter
       in: query
-      description: 'Ex: { "name": "AppInit DLLs" }'
+      description: 'Ex: {"stix.name":"AppInit DLLs"}'
       required: false
       type: string
     - name: sort
       in: query
-      description: 'Ex: { "name": "1" } or { "name": "-1"}'
+      description: 'Ex: {"stix.name":"1"} or {"stix.name":"-1"}'
       required: false
       type: string
     - name: limit
@@ -29,7 +29,7 @@ get:
       type: number
     - name: project
       in: query
-      description: 'Ex: { "name": 1 } or { "name": 0}'
+      description: 'Ex: {"stix.created_by_ref":1} or {"stix.created_by_ref":0}'
       required: false
       type: string
   

--- a/unfetter-discover-api/api/swagger/paths/x_unfetter_assessments/attack-kill-chain.yaml
+++ b/unfetter-discover-api/api/swagger/paths/x_unfetter_assessments/attack-kill-chain.yaml
@@ -14,12 +14,12 @@ get:
     format: JSON
   - name: filter
     in: query
-    description: 'Ex: { "name": "AppInit DLLs" }'
+    description: 'Ex: {"stix.name":"AppInit DLLs"}'
     required: false
     type: string
   - name: sort
     in: query
-    description: 'Ex: { "name": "1" } or { "name": "-1"}'
+    description: 'Ex: {"stix.name":"1"} or {"stix.name":"-1"}'
     required: false
     type: string
   - name: limit

--- a/unfetter-discover-api/api/swagger/paths/x_unfetter_sensors/x_unfetter_sensors.yaml
+++ b/unfetter-discover-api/api/swagger/paths/x_unfetter_sensors/x_unfetter_sensors.yaml
@@ -10,12 +10,12 @@ get:
   parameters:
     - name: filter
       in: query
-      description: 'Ex: { "name": "The Black Vine Cyberespionage Group" }'
+      description: 'Ex: {"stix.name":"The Black Vine Cyberespionage Group"}'
       required: false
       type: string
     - name: sort
       in: query
-      description: 'Ex: { "name": "1" } or { "name": "-1"}'
+      description: 'Ex: {"stix.name":"1"} or {"stix.name":"-1"}'
       required: false
       type: string
     - name: limit
@@ -38,7 +38,7 @@ get:
       description: boolean to include extended meta properties
     - name: project
       in: query
-      description: 'Ex: { "name": 1 } or { "name": 0}'
+      description: 'Ex: {"stix.created_by_ref":1} or {"stix.created_by_ref":0}'
       required: false
       type: string
   responses:


### PR DESCRIPTION
Spaces in swagger API example text for filter, sort, and project fields removed to prevent conversion of double quotes (hex 22) to extended ASCII double quotes (hex 94).

fixes unfetter-discover/unfetter#775

## To test:

1. Pull this branch
2. Build unfetter-discover-api:  docker-compose -f docker-compose.development.yml build
3. Start Unfetter:  docker-compose -f docker-compose.development.yml up &
4. Access “API Docs”
5. Expand “GET” for any of the STIX APIs
6. Click “Try it out”
7. Copy the example text (included braces) for filter, sort, or project and adjust value appropriately
8. Click Execute and verify return code 200 (SUCCESS)
