### PR TITLE
load values on startup, better lint

### DIFF
--- a/unfetter-discover-api/.eslintrc.json
+++ b/unfetter-discover-api/.eslintrc.json
@@ -1,19 +1,27 @@
 {
-    "extends": "airbnb-base",
-    "plugins": [
-        "import"
+  "extends": "airbnb-base",
+  "plugins": [
+    "import"
+  ],
+  "rules": {
+    // ignore the dangle rule, mongo used _id
+    "no-underscore-dangle": 0,
+    "comma-dangle": 0,
+    "no-console": 0,
+    "consistent-return": 0,
+    "max-len": 0,
+    "no-restricted-syntax": 0,
+    "no-var": 0,
+    "indent": [
+      "warn",
+      4
     ],
-    "rules": {
-      // ignore the dangle rule, mongo used _id
-      "no-underscore-dangle": 0,
-      "comma-dangle": 0,
-      "no-console": 0,
-      "consistent-return": 0,
-      "max-len": 0,
-      "no-restricted-syntax": 0,
-      "no-var": 0
-    },
-    "env": {
-      "jasmine": true
-    }
+    "arrow-parens": [
+      "error",
+      "always"
+    ]
+  },
+  "env": {
+    "jasmine": true
+  }
 }

--- a/unfetter-discover-api/api/server/mongoinit.js
+++ b/unfetter-discover-api/api/server/mongoinit.js
@@ -2,14 +2,44 @@ process.env.MONGO_REPOSITORY = process.env.MONGO_REPOSITORY || 'localhost';
 process.env.MONGO_PORT = process.env.MONGO_PORT || 27018;
 process.env.MONGO_DBNAME = process.env.MONGO_DBNAME || 'stix';
 
+const modelFactory = require('../controllers/shared/modelFactory');
 const mongoose = require('mongoose');
+
+const identityModel = modelFactory.getModel('identity');
+
+const mongoDebug = process.env.MONGO_DEBUG || true;
+mongoose.set('debug', mongoDebug);
 mongoose.Promise = global.Promise;
 
-module.exports = () => {
-    if (global.conn === undefined) {
+/**
+ * @description populate global lookup values
+ */
+const lookupGlobalValues = () => {
+    console.log('looking up global values...');
+    if (global.unfetter.identities === undefined) {
+        identityModel
+            .findOne({ 'stix.type': 'identity', 'stix.name': 'Unfetter Open' })
+            .exec((err, result) => {
+                if (err) {
+                    return;
+                }
+
+                const openIdent = { ...result };
+                global.unfetter.identities = [
+                    ...(global.unfetter.identities || []),
+                    openIdent,
+                ];
+                global.unfetter.openIdentity = openIdent;
+                console.log('set open identity with id, ', openIdent._id || '');
+            });
+    }
+};
+module.exports = () => new Promise((resolve, reject) => {
+    global.unfetter = global.unfetter || {};
+    if (global.unfetter.conn === undefined) {
         mongoose.connect(`mongodb://${process.env.MONGO_REPOSITORY}:${process.env.MONGO_PORT}/stix`, {
             server: {
-                poolSize: 5,
+                poolSize: 12,
                 reconnectTries: 100,
                 socketOptions: {
                     keepAlive: 300000,
@@ -18,15 +48,24 @@ module.exports = () => {
             }
         });
 
-        const db = global.conn = mongoose.connection;
-        db.on('error', console.error.bind(console, 'connection error:'));
-        db.on('connected', () => console.log('connected to mongodb'));
+        global.unfetter.conn = mongoose.connection;
+        const db = global.unfetter.conn;
+        db.on('error', () => {
+            console.error(console, 'connection error:');
+            reject('error connecting to monogo');
+        });
+        db.on('connected', () => {
+            console.log('connected to mongodb');
+            lookupGlobalValues();
+            resolve(global.unfetter.conn);
+        });
         db.on('disconnected', () => console.log('disconnected from mongodb'));
-        process.on('SIGINT', function () {
-            db.close(function () {
+        process.on('SIGINT', () => {
+            db.close(() => {
                 console.log('Safely closed MongoDB Connection');
                 process.exit(0);
             });
         });
-    }     
-};
+    }
+    resolve(global.unfetter.conn);
+});

--- a/unfetter-discover-api/api/server/server.js
+++ b/unfetter-discover-api/api/server/server.js
@@ -1,50 +1,16 @@
 process.env.RUN_MODE = process.env.RUN_MODE || 'DEMO';
-const port = process.env.PORT || '3000';
+const mongoinit = require('./mongoinit.js');
+const serverinit = require('./serverinit.js');
 
-const app = require('../../app');
-const fs = require('fs');
-const spdy = require('spdy');
-const mongoinit = require('./mongoinit.js')();
+const err =
+  (errMsg) => {
+    console.log('Failed to start http server, giving up', errMsg);
+  };
 
-app.set('port', port);
+global.unfetter = global.unfetter || {};
 
-const server = spdy.createServer({
-  key: fs.readFileSync('/etc/pki/tls/certs/server.key'),
-  cert: fs.readFileSync('/etc/pki/tls/certs/server.crt')
-}, app);
-
-server.listen(port);
-server.on('error', onError);
-server.on('listening', onListening);
-
-function onError(error) {
-  if (error.syscall !== 'listen') {
-    throw error;
-  }
-
-  var bind = typeof port === 'string' ?
-    'Pipe ' + port :
-    'Port ' + port;
-
-  // handle specific listen errors with friendly messages
-  switch (error.code) {
-    case 'EACCES':
-      console.error(bind + ' requires elevated privileges');
-      process.exit(1);
-      break;
-    case 'EADDRINUSE':
-      console.error(bind + ' is already in use');
-      process.exit(1);
-      break;
-    default:
-      throw error;
-  }
-}
-
-function onListening() {
-  var addr = server.address();
-  var bind = typeof addr === 'string' ?
-    'pipe ' + addr :
-    'port ' + addr.port;
-  console.log('Listening on ' + bind);
-}
+mongoinit()
+  .then(async () => {
+    console.log('connected to mongodb, starting api http server...');
+    await serverinit().catch(err);
+  }).catch(err);

--- a/unfetter-discover-api/api/server/serverinit.js
+++ b/unfetter-discover-api/api/server/serverinit.js
@@ -1,0 +1,54 @@
+const port = process.env.PORT || '3000';
+
+const app = require('../../app');
+const fs = require('fs');
+const spdy = require('spdy');
+
+
+const onListening = (server, resolveCallBack) => {
+    const addr = server.address();
+    const bind = typeof addr === 'string' ?
+        `pipe ${addr}` : `port ${addr.port}`;
+    console.log(`Listening on ${bind}`);
+    resolveCallBack(global.unfetter.httpServer);
+};
+
+const onError = (error, rejectCallBack) => {
+    if (error.syscall !== 'listen') {
+        throw error;
+    }
+
+    const bind = typeof port === 'string' ?
+        `Pipe ${port}` : `Port ${port}`;
+
+    // handle specific listen errors with friendly messages
+    switch (error.code) {
+        case 'EACCES':
+            console.error(`${bind} requires elevated privileges`);
+            process.exit(1);
+            break;
+        case 'EADDRINUSE':
+            console.error(`${bind} is already in use`);
+            process.exit(1);
+            break;
+        default:
+            throw error;
+    }
+    rejectCallBack(error.code);
+};
+
+module.exports = () => new Promise((resolve, reject) => {
+    global.unfetter = global.unfetter || {};
+    if (global.unfetter.httpServer === undefined) {
+        app.set('port', port);
+        const server = spdy.createServer({
+            key: fs.readFileSync('/etc/pki/tls/certs/server.key'),
+            cert: fs.readFileSync('/etc/pki/tls/certs/server.crt')
+        }, app);
+        server.listen(port);
+        server.on('error', (error) => onError(error, reject));
+        server.on('listening', () => onListening(server, resolve));
+        global.unfetter.httpServer = server;
+    }
+    resolve(global.unfetter.httpServer);
+});


### PR DESCRIPTION
fixes unfetter-discover/unfetter#781

++mongo connection pool size
better lint
sets values on startup

## To Test
* Pull this PR
* restart stack
* visit webapp, ensure it works
* `npm run lint` returns fewer errors
* in development mode, connecting robo3t or similar will not cause connection warnings