### PR TITLE
added token refreshing to swagger api

### DIFF
--- a/unfetter-api-explorer/package-lock.json
+++ b/unfetter-api-explorer/package-lock.json
@@ -364,6 +364,15 @@
       "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
       "dev": true
     },
+    "axios": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
+      "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
+      "requires": {
+        "follow-redirects": "1.4.1",
+        "is-buffer": "1.1.6"
+      }
+    },
     "babel-code-frame": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
@@ -3011,6 +3020,24 @@
         "readable-stream": "2.3.3"
       }
     },
+    "follow-redirects": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.4.1.tgz",
+      "integrity": "sha512-uxYePVPogtya1ktGnAAXOacnbIuRMB4dkvqeNz2qTtTQsuzSfbDolV+wMMKxAmCx0bLgAKLbBOkjItMbbkR1vg==",
+      "requires": {
+        "debug": "3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -4848,8 +4875,7 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-builtin-module": {
       "version": "1.0.0",
@@ -6227,8 +6253,7 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "multer": {
       "version": "1.3.0",

--- a/unfetter-api-explorer/package.json
+++ b/unfetter-api-explorer/package.json
@@ -28,6 +28,7 @@
     "webpack-dev-server": "^2.11.1"
   },
   "dependencies": {
+    "axios": "^0.18.0",
     "swagger-ui-dist": "^3.9.3"
   }
 }

--- a/unfetter-api-explorer/src/js/app.js
+++ b/unfetter-api-explorer/src/js/app.js
@@ -3,18 +3,67 @@ import { SwaggerUIBundle, SwaggerUIStandalonePreset } from 'swagger-ui-dist';
 
 // ~~~ Init SCSS ~~~
 import '../scss/main.scss';
+import { refreshToken } from './refresh-token';
+import { getConfig } from './get-config';
 
 const mainEl = 'main';
+// Grace period between attempts to refresh JWT token
+const refreshBuffer = 0.3;
+
+function showErrorCard(title, body) {
+    const el = document.getElementById(mainEl);
+    el.innerHTML = `
+        <div class="uf-container">
+            <br><br>
+            <div class="uf-error-card">
+                <h4>Error: ${title}</h4>
+                <p class="uf-well-warn">${body}</p>
+            </div>
+        </div>
+    `;
+}
 
 (() => {
-    window.onload = function () {
-
+    window.onload = function () {       
         const urlParams = new URLSearchParams(window.location.search);
 
         if (urlParams.has('token')) {
 
-            const token = urlParams.get('token');
-            // TODO verify token
+            let token = urlParams.get('token');
+            let tokenRefreshMs = 10000;
+            refreshToken(token)
+                .then((response) => {
+                    if (response.data.data && response.data.data.attributes && response.data.data.attributes.token) {
+                        token = response.data.data.attributes.token;
+                        getConfig(token)
+                            .then((config) => {
+                                if (config.data && config.data.data && config.data.data.length && config.data.data[0].attributes && config.data.data[0].attributes.configValue) {
+                                    tokenRefreshMs = config.data.data[0].attributes.configValue * 1000;
+                                    tokenRefreshMs = Math.floor(tokenRefreshMs - (refreshBuffer * tokenRefreshMs));
+                                    setInterval(() => {
+                                        refreshToken(token)
+                                            .then((response) => {
+                                                if (response.data.data && response.data.data.attributes && response.data.data.attributes.token) {
+                                                    console.log('Token refreshed');
+                                                    token = response.data.data.attributes.token;
+                                                } else {
+                                                    showErrorCard('Unable to Refresh Token', 'Reopen API Documentation from Unfetter.');
+                                                }
+                                            })
+                                    }, tokenRefreshMs);
+                                }
+                                console.log('CONFIG~~~~', config);
+                            })
+                            .catch((err) => {
+                                showErrorCard('Unable to Get Configurations', 'This instance of Unfetter is likely misconfigured.  Contact an admin.');
+                            });
+                    } else {
+                        showErrorCard('Unable to Refresh Token', 'Reopen API Documentation from Unfetter.');
+                    }
+                })
+                .catch((err) => {
+                    showErrorCard('Unable to Refresh Token', 'Reopen API Documentation from Unfetter.');
+                });
 
             window['SwaggerUIBundle'] = window['swagger-ui-bundle']
             window['SwaggerUIStandalonePreset'] = window['swagger-ui-standalone-preset']
@@ -39,17 +88,7 @@ const mainEl = 'main';
             window.ui = ui;
             
         } else {
-            // No token present
-            const el = document.getElementById(mainEl);
-            el.innerHTML = `
-                <div class="uf-container">
-                    <br><br>
-                    <div class="uf-error-card">
-                        <h4>Error: You Must Enter Through Unfetter</h4>
-                        <p class="uf-well-warn">To enter this documentation site, you must authenticate to the Unfetter user interface and use the <strong>API Documentation</strong> in the application menu.</p>
-                    </div>
-                </div>
-            `;
+            showErrorCard('You Must Enter Through Unfetter', 'To enter this documentation site, you must authenticate to the Unfetter user interface and use the <strong>API Documentation</strong> in the application menu.');
         }
     }
 })();

--- a/unfetter-api-explorer/src/js/get-config.js
+++ b/unfetter-api-explorer/src/js/get-config.js
@@ -1,0 +1,11 @@
+import * as axios from 'axios';
+
+export function getConfig(token) {
+    const config = {
+        headers: {
+            authorization: token
+        }
+    };
+    const filter = encodeURI(JSON.stringify({ configKey: 'jwtDurationSeconds' }));
+    return axios.get(`/api/config?filter=${filter}`, config);
+}

--- a/unfetter-api-explorer/src/js/refresh-token.js
+++ b/unfetter-api-explorer/src/js/refresh-token.js
@@ -1,0 +1,10 @@
+import * as axios from 'axios';
+
+export function refreshToken(token) {
+    const config = {
+        headers: {
+            authorization: token
+        }
+    };
+    return axios.get('/api/auth/refreshtoken', config);
+}


### PR DESCRIPTION
Instructions: 

- In a mongo shell, `db.getCollection('config').update({'configKey':'jwtDurationSeconds'}, { $set: { 'configValue': 150 } })` (Note, 150 is a guess, this may have to be changed)
- Restart stack
- Go to API docs, confirm you can use the documentation (eg get 1 attack pattern)
-  Wait for ~2 minutes and see if there was a successful token refresh - there should be a console.log but network tab would be good too!
- After refresh, confirm you can still documentation

Cleanup: 

- In a mongo shell return jwt duration to default, `db.getCollection('config').update({'configKey':'jwtDurationSeconds'}, { $set: { 'configValue': 900 } })`

fixes unfetter-discover/unfetter#791