### PR TITLE
apply security filter for assessments only, handle all verbs get, get…

### DIFF
--- a/unfetter-discover-api/api/controllers/x_unfetter_assessments.js
+++ b/unfetter-discover-api/api/controllers/x_unfetter_assessments.js
@@ -1007,45 +1007,9 @@ const latestAssessments = (req, res) => {
   latestAssessmentPromise(latestAssessmentsByCreatedByRefs, req, res);
 };
 
-const getById = (req, res) => {
-  return getByIdCb((err, result, req, res, id) => {
-    if (err) {
-      return res.status(500).json({ errors: [{ status: 500, source: '', title: 'Error', code: '', detail: 'An unknown error has occurred.' }] });
-    }
-
-    if (result && result.length === 1) {
-      const requestedUrl = apiRoot + req.originalUrl;
-      const data = DataHelper.getEnhancedData(result, req.swagger.params);
-      const convertedResult = jsonApiConverter.convertJsonToJsonApi(data[0], XUnfetterAssessmentType, requestedUrl);
-      return res.status(200).json({ links: { self: requestedUrl, }, data: convertedResult });
-    }
-
-    return res.status(404).json({ message: `No item found with id ${id}` });
-  });
-}
-
-const getByIdCb = (callback) => {
-  const model = XUnfetterAssessment;
-  return (req, res) => {
-    res.header('Content-Type', 'application/vnd.api+json');
-
-    const id = req.swagger.params.id ? req.swagger.params.id.value : '';
-
-    // get the most recent one since there could be many with the same id
-    // stix most recent is defined as the most recently modified one
-    model
-      .find(SecurityHelper.applySecurityFilter({ _id: id }, req.user))
-      .sort({ modified: '-1' })
-      .limit(1)
-      .exec((err, result) => {
-        callback(err, result, req, res, id);
-      });
-  }
-}
-
 module.exports = {
   get: controller.get(),
-  getById: getById(),
+  getById: controller.getById(),
   add: controller.add(),
   update: controller.update(),
   deleteById: controller.deleteById(),

--- a/unfetter-discover-api/api/helpers/security_helper.js
+++ b/unfetter-discover-api/api/helpers/security_helper.js
@@ -35,12 +35,14 @@ const isAdmin = (user) => {
  */
 const applySecurityFilter = (query, user) => {
     if (!query || process.env.RUN_MODE !== 'UAC' || !user) {
+        console.log(`skipping filter for query=${query}, RUN_MODE=${process.env.RUN_MODE}, user=${user}`)
         return query;
     }
 
     const hasAdmin = isAdmin(user);
     // if admin, do not apply security filter
     if (hasAdmin === true) {
+        console.log(`skipping filter for admin ${user.id}`);
         return query;
     }
 


### PR DESCRIPTION
apply security filter for assessments only, handle all verbs get, get by id, update, delete

## To Test
* pull this feature branch
* create 2 accounts
* optionally open `mongoinit.js` and set the moongose debug to true (this will show queries sent to db)
* give user2; non admin, and non relevant orgs
* user1 should create some assessments
* visit the swagger api in two browsers
* user2 should _not_ be able to execute the following assessments operations; get, getbyid, update, and delete commands
  * get sample; `{ "stix.id": "x-unfetter-assessment--fc20a6e8-e486-4b3c-aa8d-765485f3e0db" }` replace w/ your id
* user1 should be able to execute the commands
 