### PR TITLE
added temporary fix for identity race condition at api startup

### DIFF
--- a/unfetter-discover-api/api/server/mongoinit.js
+++ b/unfetter-discover-api/api/server/mongoinit.js
@@ -27,7 +27,28 @@ const lookupGlobalValues = () => new Promise((resolve, reject) =>{
 
     Promise.all(promises)
         .then(([identity, configurations]) => {
-            const openIdent = { ...identity.toObject() };
+            let openIdent;
+            if (identity) {
+                console.log('Open identity set to saved document');
+                openIdent = { ...identity.toObject() };
+            } else {
+                console.log('Open identity set to default');
+                openIdent = {
+                    _id: 'identity--e240b257-5c42-402e-a0e8-7b81ecc1c09a',
+                    stix: {
+                        name: 'Unfetter Open',
+                        identity_class: 'organization',
+                        id: 'identity--e240b257-5c42-402e-a0e8-7b81ecc1c09a',
+                        description: 'This is an organization open to all Unfetter users.',
+                        type: 'identity',
+                        modified: '2017-11-01T18:42:35.073Z',
+                        created: '2017-11-01T18:36:59.472Z',
+                        labels: [
+                            'open-group'
+                        ]
+                    }
+                };
+            }
             global.unfetter.identities = [
                 ...(global.unfetter.identities || []),
                 openIdent,


### PR DESCRIPTION
Requirements: `master` on `unfetter` and `unfetter-ui`, `issue-869` on `unfetter-store`

Note: This is to fix a race condition occurring with docker hub images, so these test instructions will be highly contrived

Instructions: 
- Delete unfetter open from the DB: `db.getCollection('stix').remove({_id: 'identity--e240b257-5c42-402e-a0e8-7b81ecc1c09a'})`
- Stop stack
- Find and delete 'Unfetter Open' from `unfetter/config/examples/unfetter-stix/stix.json`
- Start stack
- Confirm API launched properly
-  Manually add 'Unfetter Open' back to the DB via 
```
db.getCollection('stix').insert({
    _id: 'identity--e240b257-5c42-402e-a0e8-7b81ecc1c09a',
    stix: {
        name: 'Unfetter Open',
        identity_class: 'organization',
        id: 'identity--e240b257-5c42-402e-a0e8-7b81ecc1c09a',
        description: 'This is an organization open to all Unfetter users.',
        type: 'identity',
        modified: '2017-11-01T18:42:35.073Z',
        created: '2017-11-01T18:36:59.472Z',
        labels: [
            'open-group'
        ]
    }
})
```
- Go to analytic hub, add an analytic with unfetter open and confirm it works
