### PR TITLE
enforce created_by_ref in mongoose models for every type except identity

### DIFF
--- a/unfetter-discover-api/api/controllers/shared/basecontroller.js
+++ b/unfetter-discover-api/api/controllers/shared/basecontroller.js
@@ -86,8 +86,6 @@ module.exports = class BaseController {
 
                     const requestedUrl = apiRoot + req.originalUrl;
                     const data = DataHelper.getEnhancedData(result, req.swagger.params);
-                    console.log('eeeeeeeee');
-                    console.log(data);
                     const convertedResult = jsonApiConverter.convertJsonToJsonApi(data, type, requestedUrl);
                     // return res.status(200).json({ links: { self: requestedUrl, }, data: convertedResult });
                     callback(err, convertedResult, requestedUrl, req, res);

--- a/unfetter-discover-api/api/models/attack-pattern.js
+++ b/unfetter-discover-api/api/models/attack-pattern.js
@@ -3,6 +3,10 @@ const stixCommons = require('./stix-commons');
 
 const AttackPatternSchema = {
     id: String,
+    created_by_ref: {
+        type: String,
+        required: [true, 'created_by_ref is required']
+    },
     name: {
         type: String,
         required: [true, 'name is required']

--- a/unfetter-discover-api/api/models/campaign.js
+++ b/unfetter-discover-api/api/models/campaign.js
@@ -3,6 +3,10 @@ const stixCommons = require('./stix-commons');
 
 const ExtendedSchema = {
     id: String,
+    created_by_ref: {
+        type: String,
+        required: [true, 'created_by_ref is required']
+    },
     name: {
         type: String,
         required: [true, 'name is required']

--- a/unfetter-discover-api/api/models/course-of-action.js
+++ b/unfetter-discover-api/api/models/course-of-action.js
@@ -3,6 +3,10 @@ const stixCommons = require('./stix-commons');
 
 const StixSchema = {
     id: String,
+    created_by_ref: {
+        type: String,
+        required: [true, 'created_by_ref is required']
+    },
     name: {
         type: String,
         required: [true, 'name is required']

--- a/unfetter-discover-api/api/models/identity.js
+++ b/unfetter-discover-api/api/models/identity.js
@@ -3,6 +3,7 @@ const stixCommons = require('./stix-commons');
 
 const StixSchema = {
     id: String,
+    created_by_ref: String,
     name: {
         type: String,
         required: [true, 'name is required']

--- a/unfetter-discover-api/api/models/indicator.js
+++ b/unfetter-discover-api/api/models/indicator.js
@@ -3,6 +3,10 @@ const stixCommons = require('./stix-commons');
 
 const StixSchema = {
     id: String,
+    created_by_ref: {
+        type: String,
+        required: [true, 'created_by_ref is required']
+    },
     labels: [String],
     name: {
         type: String

--- a/unfetter-discover-api/api/models/intrusion-set.js
+++ b/unfetter-discover-api/api/models/intrusion-set.js
@@ -3,6 +3,10 @@ const stixCommons = require('./stix-commons');
 
 const StixSchema = {
     id: String,
+    created_by_ref: {
+        type: String,
+        required: [true, 'created_by_ref is required']
+    },
     name: {
         type: String,
         required: [true, 'name is required']

--- a/unfetter-discover-api/api/models/malware.js
+++ b/unfetter-discover-api/api/models/malware.js
@@ -3,6 +3,10 @@ const stixCommons = require('./stix-commons');
 
 const StixSchema = {
     id: String,
+    created_by_ref: {
+        type: String,
+        required: [true, 'created_by_ref is required']
+    },
     labels: [String],
     name: {
         type: String,

--- a/unfetter-discover-api/api/models/observed-data.js
+++ b/unfetter-discover-api/api/models/observed-data.js
@@ -3,6 +3,10 @@ const stixCommons = require('./stix-commons');
 
 const StixSchema = {
     id: String,
+    created_by_ref: {
+        type: String,
+        required: [true, 'created_by_ref is required']
+    },
     first_observed: {
         type: Date,
         default: Date.now,

--- a/unfetter-discover-api/api/models/relationship.js
+++ b/unfetter-discover-api/api/models/relationship.js
@@ -3,6 +3,10 @@ const stixCommons = require('./stix-commons');
 
 const StixSchema = {
     id: String,
+    created_by_ref: {
+        type: String,
+        required: [true, 'created_by_ref is required']
+    },
     relationship_type: {
         type: String,
         match: /^[a-z0-9\\-]+$/,

--- a/unfetter-discover-api/api/models/report.js
+++ b/unfetter-discover-api/api/models/report.js
@@ -3,6 +3,10 @@ const stixCommons = require('./stix-commons');
 
 const StixSchema = {
     id: String,
+    created_by_ref: {
+        type: String,
+        required: [true, 'created_by_ref is required']
+    },
     name: {
         type: String,
         required: [true, 'name is required']
@@ -12,19 +16,7 @@ const StixSchema = {
     },
     labels: [{
         type: String,
-        required: [true, 'label(s) are required'],
-        enum: [
-            'threat-report',
-            'attack-pattern',
-            'campaign',
-            'identity',
-            'indicator',
-            'malware',
-            'observed-data',
-            'threat-actor',
-            'tool',
-            'vulnerability'
-        ]
+        required: [true, 'label(s) are required']
     }],
     published: {
         type: Date,

--- a/unfetter-discover-api/api/models/sighting.js
+++ b/unfetter-discover-api/api/models/sighting.js
@@ -3,6 +3,10 @@ const stixCommons = require('./stix-commons');
 
 const StixSchema = {
     id: String,
+    created_by_ref: {
+        type: String,
+        required: [true, 'created_by_ref is required']
+    },
     first_seen: {
         type: Date,
         default: Date.now

--- a/unfetter-discover-api/api/models/stix-commons.js
+++ b/unfetter-discover-api/api/models/stix-commons.js
@@ -74,7 +74,6 @@ stixCommons.discriminator = {
 
 stixCommons.baseStix = {
     id: String,
-    created_by_ref: String,
     created: {
         type: Date,
         default: Date.now,

--- a/unfetter-discover-api/api/models/threat-actor.js
+++ b/unfetter-discover-api/api/models/threat-actor.js
@@ -3,6 +3,10 @@ const stixCommons = require('./stix-commons');
 
 const StixSchema = {
     id: String,
+    created_by_ref: {
+        type: String,
+        required: [true, 'created_by_ref is required']
+    },
     name: {
         type: String,
         required: [true, 'name is required']

--- a/unfetter-discover-api/api/models/tool.js
+++ b/unfetter-discover-api/api/models/tool.js
@@ -3,6 +3,10 @@ const stixCommons = require('./stix-commons');
 
 const StixSchema = {
     id: String,
+    created_by_ref: {
+        type: String,
+        required: [true, 'created_by_ref is required']
+    },
     labels: [String],
     name: {
         type: String,

--- a/unfetter-discover-api/api/models/x-unfetter-assessment.js
+++ b/unfetter-discover-api/api/models/x-unfetter-assessment.js
@@ -2,6 +2,10 @@ const mongoose = require('mongoose');
 const stixCommons = require('./stix-commons');
 
 const StixSchema = {
+    created_by_ref: {
+        type: String,
+        required: [true, 'created_by_ref is required']
+    },
     id: String,
     name: {
         type: String,

--- a/unfetter-discover-api/api/models/x-unfetter-sensor.js
+++ b/unfetter-discover-api/api/models/x-unfetter-sensor.js
@@ -3,6 +3,10 @@ const stixCommons = require('./stix-commons');
 
 const StixSchema = {
     id: String,
+    created_by_ref: {
+        type: String,
+        required: [true, 'created_by_ref is required']
+    },
     name: {
         type: String,
         required: [true, 'name is required']


### PR DESCRIPTION
To test:
- Confirm creation of objects works in threat dashboard, assessments, and analytic hub
- Select a few STIX crud pages and create new STIX
- Ensure `created_by_ref` is returned on new objects

fixes unfetter-discover/unfetter#787