### PR TITLE
security filter on latest calls

### DIFF
--- a/unfetter-discover-api/api/controllers/latest.js
+++ b/unfetter-discover-api/api/controllers/latest.js
@@ -173,7 +173,7 @@ const getLatestThreatReportsByCreatorId = (req, res) => {
         },
         ...threatReportGroupAndUnwind()
     ];
-    console.log(JSON.stringify(latestByCreatorWithRollup));
+    // console.log(JSON.stringify(latestByCreatorWithRollup));
     callPromise(latestByCreatorWithRollup, req, res);
 };
 
@@ -194,7 +194,7 @@ const getLatestThreatReports = (req, res) => {
         },
         ...threatReportGroupAndUnwind()
     ];
-    console.log(JSON.stringify(latest));
+    // console.log(JSON.stringify(latest));
     callPromise(latest, req, res);
 };
 

--- a/unfetter-discover-api/api/controllers/latest.js
+++ b/unfetter-discover-api/api/controllers/latest.js
@@ -1,8 +1,22 @@
 const mongoose = require('mongoose');
+const SecurityHelper = require('../helpers/security_helper');
 
 const schema = mongoose.Schema({}, {
     strict: false
 });
+
+const writeErrorResp = (res, msg) => {
+    const detail = msg || 'An unknown error has occurred.';
+    return res.status(500).json({
+        error: {
+            status: 500,
+            source: '',
+            title: 'Error',
+            code: '',
+            detail: detail,
+        },
+    });
+};
 
 const callPromise = (query, req, res) => {
     const aggregationModel = modelFactory();
@@ -16,63 +30,67 @@ const callPromise = (query, req, res) => {
                 data: results
             });
         })
-        .catch(err => // eslint-disable-line no-unused-vars
-            res.status(500).json({
-                errors: [{
-                    status: 500,
-                    source: '',
-                    title: 'Error',
-                    code: '',
-                    detail: 'An unknown error has occurred.'
-                }]
-            }));
+        .catch((err) => {
+            writeErrorResp(res, err);
+        });
 };
 
 /**
  * @description fetch stix of given type for given creator id, sort base on last modified
- */
+*/
 const getLatestByTypeAndCreatorId = (req, res) => {
     res.header('Content-Type', 'application/vnd.api+json');
     const id = req.swagger.params.id ? req.swagger.params.id.value : '';
     const type = req.swagger.params.type ? req.swagger.params.type.value : '';
 
+    // const user = req.user;
+    // const requestorId = user && user._id.toString() ? user._id.toString() : '';
+    // const isAdmin = SecurityHelper.isAdmin(req.user);
+    // console.log(requestorId + ' ' + id + ' ' + isAdmin);
+    // if (isAdmin === false && requestorId.trim() !== id.trim()) {
+    //     console.log('cannot query');
+    //     return writeErrorResp(res, 'non admin requestor must query for their own creatorId');
+    // }
+    let query = {
+        creator: id,
+        'stix.type': type
+    };
+    query = SecurityHelper.applySecurityFilter(query, req.user);
     // aggregate pipeline
     //  match on given user and given type
     //  sort on last modified
-    const latestByTypeAndCreator = [{
-        $match: {
-            creator: id,
-            'stix.type': type
-        }
-    },
-    {
-        $group: {
-            _id: '$stix.id',
-            id: {
-                $push: '$stix.id'
-            },
-            name: {
-                $first: '$stix.name'
-            },
-            type: {
-                $first: '$stix.type'
-            },
-            modified: {
-                $max: '$stix.modified'
-            },
-            create_by_ref: {
-                $first: '$creator'
+    const latestByTypeAndCreator = [
+        {
+            $match: query,
+        },
+        {
+            $group: {
+                _id: '$stix.id',
+                id: {
+                    $push: '$stix.id'
+                },
+                name: {
+                    $first: '$stix.name'
+                },
+                type: {
+                    $first: '$stix.type'
+                },
+                modified: {
+                    $max: '$stix.modified'
+                },
+                creator: {
+                    $first: '$creator'
+                }
+            }
+        },
+        {
+            $unwind: '$id'
+        },
+        {
+            $sort: {
+                modified: -1
             }
         }
-    },
-    {
-        $unwind: '$id'
-    },
-    {
-        $sort: {
-            modified: -1
-        }
-    }
     ];
 
     callPromise(latestByTypeAndCreator, req, res);
@@ -83,45 +101,48 @@ const getLatestByTypeAndCreatorId = (req, res) => {
  */
 const getLatestByType = (req, res) => {
     res.header('Content-Type', 'application/vnd.api+json');
+    const type = req.swagger.params.type ? req.swagger.params.type.value : '';
 
+    let query = {
+        'stix.type': type
+    };
+    query = SecurityHelper.applySecurityFilter(query, req.user);
     // aggregate pipeline
     //  match on type
     //  sort on last modified
-    const latestByType = [{
-        $match: {
-            'stix.type': 'report'
-        }
-    },
-    {
-        $group: {
-            _id: '$stix.id',
-            id: {
-                $push: '$stix.id'
-            },
-            name: {
-                $first: '$stix.name'
-            },
-            type: {
-                $first: '$stix.type'
-            },
-            modified: {
-                $max: '$stix.modified'
-            },
-            create_by_ref: {
-                $first: '$creator'
+    const latestByType = [
+        {
+            $match: query,
+        },
+        {
+            $group: {
+                _id: '$stix.id',
+                id: {
+                    $push: '$stix.id'
+                },
+                name: {
+                    $first: '$stix.name'
+                },
+                type: {
+                    $first: '$stix.type'
+                },
+                modified: {
+                    $max: '$stix.modified'
+                },
+                created_by_ref: {
+                    $first: '$stix.created_by_ref'
+                }
+            }
+        },
+        {
+            $unwind: '$id'
+        },
+        {
+            $sort: {
+                modified: -1
             }
         }
-    },
-    {
-        $unwind: '$id'
-    },
-    {
-        $sort: {
-            modified: -1
-        }
-    }
     ];
-
     callPromise(latestByType, req, res);
 };
 
@@ -129,48 +150,61 @@ const getLatestByType = (req, res) => {
 /**
  * @description fetch stix of given type for given creator id, sort base on last modified
  */
-const getLatestThreatReportByCreatorId = (req, res) => {
+const getLatestThreatReportsByCreatorId = (req, res) => {
     const id = req.swagger.params.id ? req.swagger.params.id.value : '';
     res.header('Content-Type', 'application/vnd.api+json');
 
+    // const user = req.user;
+    // const requestorId = user && user._id.toString() ? user._id.toString() : '';
+    // const isAdmin = SecurityHelper.isAdmin(req.user);
+    // console.log(requestorId + ' ' + id + ' ' + isAdmin);
+    // if (isAdmin === false && requestorId.trim() !== id.trim()) {
+    //     return writeErrorResp(res, 'non admin requestor must query for their own creatorId');
+    // }
+    let query = {
+        creator: id,
+        'stix.type': 'report'
+    };
+    query = SecurityHelper.applySecurityFilter(query, req.user);
     // aggregate pipeline
-    const latestByCreatorWithRollup = [{
-        $match: {
-            creator: id,
-            'stix.type': 'report'
-        }
-    },
-        ...threatReportAggregateGroupAndUnwind()
+    const latestByCreatorWithRollup = [
+        {
+            $match: query,
+        },
+        ...threatReportGroupAndUnwind()
     ];
-
+    console.log(JSON.stringify(latestByCreatorWithRollup));
     callPromise(latestByCreatorWithRollup, req, res);
 };
 
 /**
  * @description fetch ids for given stix type, sort base on last modified
  */
-const getLatestThreatReport = (req, res) => {
+const getLatestThreatReports = (req, res) => {
     res.header('Content-Type', 'application/vnd.api+json');
 
+    let query = {
+        'stix.type': 'report'
+    };
+    query = SecurityHelper.applySecurityFilter(query, req.user);
     // aggregate pipeline
-    const latestThreatReport = [{
-        $match: {
-            'stix.type': 'report'
-        }
-    },
-        ...threatReportAggregateGroupAndUnwind()
+    const latest = [
+        {
+            $match: query,
+        },
+        ...threatReportGroupAndUnwind()
     ];
-
-    callPromise(latestThreatReport, req, res);
+    console.log(JSON.stringify(latest));
+    callPromise(latest, req, res);
 };
 
-const threatReportAggregateGroupAndUnwind = () =>
+const threatReportGroupAndUnwind = () => {
     // aggregate pipeline
     // no match
     // group on workproduct ids
     // unwind the arrays
     // sort on last modified
-    [{
+    return [{
         $group: {
             _id: '$metaProperties.work_products.id',
             workproductId: {
@@ -188,8 +222,8 @@ const threatReportAggregateGroupAndUnwind = () =>
             modified: {
                 $max: '$stix.modified'
             },
-            create_by_ref: {
-                $first: '$creator'
+            created_by_ref: {
+                $first: '$stix.created_by_ref'
             }
         }
     },
@@ -203,15 +237,14 @@ const threatReportAggregateGroupAndUnwind = () =>
         $sort: {
             modified: -1
         }
-    }
-    ];
-
+    }];
+};
 
 const modelFactory = () => mongoose.model('aggregations', schema, 'stix');
 
 module.exports = {
     getLatestByTypeAndCreatorId,
     getLatestByType,
-    getLatestThreatReport,
-    getLatestThreatReportByCreatorId,
+    getLatestThreatReports,
+    getLatestThreatReportsByCreatorId,
 };

--- a/unfetter-discover-api/api/controllers/latest.js
+++ b/unfetter-discover-api/api/controllers/latest.js
@@ -13,7 +13,7 @@ const writeErrorResp = (res, msg) => {
             source: '',
             title: 'Error',
             code: '',
-            detail: detail,
+            detail,
         },
     });
 };
@@ -30,7 +30,7 @@ const callPromise = (query, req, res) => {
                 data: results
             });
         })
-        .catch((err) => {
+        .catch(err => {
             writeErrorResp(res, err);
         });
 };
@@ -198,13 +198,13 @@ const getLatestThreatReports = (req, res) => {
     callPromise(latest, req, res);
 };
 
-const threatReportGroupAndUnwind = () => {
+const threatReportGroupAndUnwind = () =>
     // aggregate pipeline
     // no match
     // group on workproduct ids
     // unwind the arrays
     // sort on last modified
-    return [{
+    [{
         $group: {
             _id: '$metaProperties.work_products.id',
             workproductId: {
@@ -238,7 +238,6 @@ const threatReportGroupAndUnwind = () => {
             modified: -1
         }
     }];
-};
 
 const modelFactory = () => mongoose.model('aggregations', schema, 'stix');
 

--- a/unfetter-discover-api/api/controllers/shared/basecontroller.js
+++ b/unfetter-discover-api/api/controllers/shared/basecontroller.js
@@ -464,8 +464,7 @@ module.exports = class BaseController {
             return query;
         }
 
-        const assessmentType = 'x-unfetter-assessment';
-        const filterTypes = new Set([assessmentType, 'indicator']);
+        const filterTypes = new Set(['x-unfetter-assessment', 'indicator', 'report']);
         if (filterTypes.has(type)) {
             console.log(`applying filter on type ${type}`);
             return SecurityHelper.applySecurityFilter(query, user, read);

--- a/unfetter-discover-api/api/helpers/security_helper.js
+++ b/unfetter-discover-api/api/helpers/security_helper.js
@@ -3,7 +3,7 @@
  * @param {*} user
  * @returns true if this user object has the admin role and is not locked, otherwise false
  */
-const isAdmin = (user) => {
+const isAdmin = user => {
     if (!user) {
         return false;
     }

--- a/unfetter-discover-api/api/helpers/security_helper.js
+++ b/unfetter-discover-api/api/helpers/security_helper.js
@@ -3,7 +3,7 @@
  * @param {*} user
  * @returns true if this user object has the admin role and is not locked, otherwise false
  */
-const isAdmin = user => {
+const isAdmin = (user) => {
     if (!user) {
         return false;
     }

--- a/unfetter-discover-api/api/swagger/paths/latest/latest-by-type-and-id.yaml
+++ b/unfetter-discover-api/api/swagger/paths/latest/latest-by-type-and-id.yaml
@@ -1,7 +1,6 @@
 x-swagger-router-controller: latest
 get:
   tags:
-  - STIX-Unfetter
   - Ids sort by modified
   description: Find all Ids of stix type given sorted by last modified
   operationId: getLatestByTypeAndCreatorId
@@ -13,7 +12,7 @@ get:
     required: true
   - name: id
     in: path
-    description: stix type
+    description: user id
     type: string
     required: true
   produces: 

--- a/unfetter-discover-api/api/swagger/paths/latest/latest-by-type.yaml
+++ b/unfetter-discover-api/api/swagger/paths/latest/latest-by-type.yaml
@@ -1,7 +1,6 @@
 x-swagger-router-controller: latest
 get:
   tags:
-  - STIX-Unfetter
   - Ids sort by modified
   description: Find all Ids of stix type given sorted by last modified
   operationId: getLatestByType

--- a/unfetter-discover-api/api/swagger/paths/latest/latest-threat-report-by-id.yaml
+++ b/unfetter-discover-api/api/swagger/paths/latest/latest-threat-report-by-id.yaml
@@ -1,14 +1,13 @@
 x-swagger-router-controller: latest
 get:
   tags:
-  - STIX-Unfetter
   - Ids sort by modified
   description: Find all Ids of stix type given sorted by last modified
-  operationId: getLatestThreatReportByCreatorId
+  operationId: getLatestThreatReportsByCreatorId
   parameters:
   - name: id
     in: path
-    description: stix type
+    description: user id
     type: string
     required: true
   produces: 

--- a/unfetter-discover-api/api/swagger/paths/latest/latest-threat-report.yaml
+++ b/unfetter-discover-api/api/swagger/paths/latest/latest-threat-report.yaml
@@ -1,10 +1,9 @@
 x-swagger-router-controller: latest
 get:
   tags:
-  - STIX-Unfetter
   - Ids sort by modified
   description: Find all Ids of stix type given sorted by last modified
-  operationId: getLatestThreatReport
+  operationId: getLatestThreatReports
   produces: 
   - application/vnd.api+json
   responses:


### PR DESCRIPTION
Apply security filter to the `get latest` objects calls

## To Test
* Get latest `unfetter develop`
* 2 accounts, 2 browsers
* browser 1, create stuff like reports, etc.  Set the submitter org
* browser 2, visit the swagger api
 * call all 4 `/latest` calls
  *  verify data returned
* also set the mongo logging (see docker-compose.development.yml MONGO_DEBUG) see the extra security filter params in the query

