### PR TITLE
Fix for mapping of ID for latest object assessments API

### DIFF
--- a/unfetter-discover-api/api/controllers/x_unfetter_object_assessments.js
+++ b/unfetter-discover-api/api/controllers/x_unfetter_object_assessments.js
@@ -16,11 +16,19 @@ const latestObjectAssessmentPromise = (query, req, res) => {
     Promise.resolve(aggregationModel.aggregate(query))
         .then(results => {
             const requestedUrl = req.originalUrl;
+
+            const mappedResults = results
+                .map(r => {
+                    const retVal = { ...r };
+                    retVal.id = r.stix.id;
+                    return retVal;
+                });
+
             return res.status(200).json({
                 links: {
                     self: requestedUrl,
                 },
-                data: results
+                data: mappedResults
             });
         })
         .catch(err => // eslint-disable-line no-unused-vars
@@ -30,7 +38,7 @@ const latestObjectAssessmentPromise = (query, req, res) => {
                     source: '',
                     title: 'Error',
                     code: '',
-                    detail: `Error getting object assessments by latest:\n${err}`
+                    detail: `Error getting latest object assessments:\n${err}`
                 }]
             }));
 };


### PR DESCRIPTION
Follow-up change for issue-885.

# To test:

1. Pull this PR
2. Restart unfetter-discover-api
3. Access API Explorer
4. For STIX-Unfetter Object Assessment, execute the 'latest' and 'latest(creator)' APIs, and make sure there is an 'id' property in the return structure.
