### PR TITLE
Framework switch

### DIFF
--- a/unfetter-ctf-ingest/src/adapters/attack-pattern-ingest-to-stix.adapter.ts
+++ b/unfetter-ctf-ingest/src/adapters/attack-pattern-ingest-to-stix.adapter.ts
@@ -63,7 +63,7 @@ export class AttackPatternIngestToStixAdapter {
         }
 
         const v4 = UUID.v4();
-        const id = stix.type + '-' + v4;
+        const id = stix.type + '--' + v4;
         stix.id = id;
         return stix;
     }

--- a/unfetter-ctf-ingest/src/adapters/rss-to-stix.adapter.ts
+++ b/unfetter-ctf-ingest/src/adapters/rss-to-stix.adapter.ts
@@ -48,7 +48,7 @@ export class RssToStixAdapter {
         }
 
         const id = UUID.v4();
-        stix.id = stix.type + '-' + id;
+        stix.id = stix.type + '--' + id;
         const sourceType = 'open source';
         const reportId = item.guid;
         const description = item.description;

--- a/unfetter-ctf-ingest/src/mocks/attack-pattern-ingest.mock.ts
+++ b/unfetter-ctf-ingest/src/mocks/attack-pattern-ingest.mock.ts
@@ -5,7 +5,7 @@ export class AttackPatternIngestMock extends Mock<AttackPatternIngest> {
 
     public mockOne(num?: number): AttackPatternIngest {
         const mock = new AttackPatternIngest();
-        mock.action = 'action' + ( '-' + num || '');
+        mock.action = 'action' + ( '--' + num || '');
         mock.description = 'description';
         mock.killChain = 'them sofly';
         mock.objective = 'world peace?';

--- a/unfetter-ctf-ingest/src/services/unfetter-poster-mongo.service.ts
+++ b/unfetter-ctf-ingest/src/services/unfetter-poster-mongo.service.ts
@@ -26,7 +26,7 @@ export class UnfetterPosterMongoService {
         const wrappedArr: WrappedStix[] = arr.map((el) => {
             if (!el.id) {
                 const v4 = UUID.v4();
-                const id = el.type + '-' + v4;
+                const id = el.type + '--' + v4;
                 el.id = id;
             }
             const wrapper: WrappedStix = {

--- a/unfetter-discover-api/.eslintrc.json
+++ b/unfetter-discover-api/.eslintrc.json
@@ -4,9 +4,11 @@
     "import"
   ],
   "rules": {
-    // ignore the dangle rule, mongo used _id
     "no-underscore-dangle": 0,
     "comma-dangle": 0,
+    "class-methods-use-this": [
+      false
+    ],
     "no-console": 0,
     "consistent-return": 0,
     "max-len": 0,
@@ -22,19 +24,30 @@
     ],
     "no-void": 0,
     "import/no-unresolved": "off",
-    "no-shadow": ["warn", { "builtinGlobals": false, "hoist": "functions", "allow": [] }],
-    "global-require":"off",
-    "prefer-destructuring": [1, {
-      "array": true,
-      "object": false
-    }, {
-      "enforceForRenamedProperties": false
-    }],
+    "no-shadow": [
+      "warn",
+      {
+        "builtinGlobals": false,
+        "hoist": "functions",
+        "allow": []
+      }
+    ],
+    "global-require": "off",
+    "prefer-destructuring": [
+      1,
+      {
+        "array": true,
+        "object": false
+      },
+      {
+        "enforceForRenamedProperties": false
+      }
+    ],
     "no-use-before-define": "off",
-    "new-cap":"off",
-    "no-unused-vars":"warn",
-    "no-param-reassign":"warn",
-    "camelcase":"warn"
+    "new-cap": "off",
+    "no-unused-vars": "warn",
+    "no-param-reassign": "warn",
+    "camelcase": "warn"
   },
   "env": {
     "jasmine": true

--- a/unfetter-discover-api/.eslintrc.json
+++ b/unfetter-discover-api/.eslintrc.json
@@ -7,7 +7,7 @@
     "no-underscore-dangle": 0,
     "comma-dangle": 0,
     "class-methods-use-this": [
-      false
+      0
     ],
     "no-console": 0,
     "consistent-return": 0,

--- a/unfetter-discover-api/api/controllers/shared/basecontroller.js
+++ b/unfetter-discover-api/api/controllers/shared/basecontroller.js
@@ -479,22 +479,4 @@ module.exports = class BaseController {
         // console.log(`skipping filter for type, ${type}`);
         // return query;
     }
-
-    /**
-     * @description apply the system kill chain filter to queries, if a filter clause does not already exist
-     * @param  {} query
-     */
-    applyKillchainFilter(query) {
-        if (!type || !query) {
-            return query;
-        }
-        const killChain = global.unfetter.killchain;
-        if (!killChain) {
-            return query;
-        }
-
-        console.log(`filtering query ${JSON.stringify(query)}`);
-        killChainFilter = { 'stix.kill_chain_phases.kill_chain_name': { $exists: true, $eq: killChain } };
-        return { ...query, ...killChainFilter };
-    }
 };

--- a/unfetter-discover-api/api/controllers/shared/basecontroller.js
+++ b/unfetter-discover-api/api/controllers/shared/basecontroller.js
@@ -224,13 +224,13 @@ module.exports = class BaseController {
                         let relType = '';
                         // TODO make this better
                         switch (type) {
-                        case 'indicator':
-                            relType = 'indicates';
-                            break;
-                        case 'x-unfetter-sensor':
-                            relType = 'detects';
-                            break;
-                        default:
+                            case 'indicator':
+                                relType = 'indicates';
+                                break;
+                            case 'x-unfetter-sensor':
+                                relType = 'detects';
+                                break;
+                            default:
                         }
                         const tempRelationship = {
                             stix: {
@@ -419,7 +419,7 @@ module.exports = class BaseController {
         };
     }
 
-    deleteByIdCb(callback) { // eslint-disable-line class-methods-use-this
+    deleteByIdCb(callback) { 
         return (req, res) => {
             res.header('Content-Type', 'application/vnd.api+json');
 
@@ -465,7 +465,7 @@ module.exports = class BaseController {
      * @param {*} type
      * @param {*} user
      */
-    applySecurityFilterWhenNeeded(query, type, user, read = true) { // eslint-disable-line class-methods-use-this
+    applySecurityFilterWhenNeeded(query, type, user, read = true) {
         if (!type || !query) {
             return query;
         }
@@ -478,5 +478,23 @@ module.exports = class BaseController {
         // }
         // console.log(`skipping filter for type, ${type}`);
         // return query;
+    }
+
+    /**
+     * @description apply the system kill chain filter to queries, if a filter clause does not already exist
+     * @param  {} query
+     */
+    applyKillchainFilter(query) {
+        if (!type || !query) {
+            return query;
+        }
+        const killChain = global.unfetter.killchain;
+        if (!killChain) {
+            return query;
+        }
+
+        console.log(`filtering query ${JSON.stringify(query)}`);
+        killChainFilter = { 'stix.kill_chain_phases.kill_chain_name': { $exists: true, $eq: killChain } };
+        return { ...query, ...killChainFilter };
     }
 };

--- a/unfetter-discover-api/api/controllers/shared/basecontroller.js
+++ b/unfetter-discover-api/api/controllers/shared/basecontroller.js
@@ -419,7 +419,7 @@ module.exports = class BaseController {
         };
     }
 
-    deleteByIdCb(callback) { 
+    deleteByIdCb(callback) {
         return (req, res) => {
             res.header('Content-Type', 'application/vnd.api+json');
 

--- a/unfetter-discover-api/api/server/mongoinit.js
+++ b/unfetter-discover-api/api/server/mongoinit.js
@@ -97,7 +97,6 @@ const lookupGlobalValues = () => new Promise((resolve, reject) => {
                 global.unfetter.JWT_DURATION_SECONDS = 900;
             }
 
-            global.unfetter.defaultFramework = process.env.KILL_CHAIN || 'mitre-attack';
             resolve('Identities recieved');
         })
         .catch(err => reject(new Error('Unable to get identities and/or configurations: '), err));

--- a/unfetter-discover-api/api/server/mongoinit.js
+++ b/unfetter-discover-api/api/server/mongoinit.js
@@ -97,6 +97,7 @@ const lookupGlobalValues = () => new Promise((resolve, reject) => {
                 global.unfetter.JWT_DURATION_SECONDS = 900;
             }
 
+            global.unfetter.defaultFramework = process.env.KILL_CHAIN || 'mitre-attack';
             resolve('Identities recieved');
         })
         .catch(err => reject(new Error('Unable to get identities and/or configurations: '), err));


### PR DESCRIPTION
supports unfetter-discover/unfetter#855

## Problem
To allow new attack patterns to live side by side in unfetter w/ its default attack patterns
To make a sane lint rule, encouraging static methods is not ideal imo

## Accomplished
* Fix the ids when I generate the new attack patterns

## To Test
* `cd unfetter-store/unfetter-ctf-ingest npm run generate:attack-pattern:fromcsv -- -f test-data/attack-patterns/ntctf-ap.csv`
* verify the ids have a double dash

