### PR TITLE
categories endpoints

### DIFF
--- a/unfetter-discover-api/api/controllers/shared/modelFactory.js
+++ b/unfetter-discover-api/api/controllers/shared/modelFactory.js
@@ -23,6 +23,8 @@ mongooseModel.user = require('../../models/user');
 
 // Assessments 3.0
 mongooseModel['x-unfetter-capability'] = require('../../models/x-unfetter-capability');
+mongooseModel['x-unfetter-category'] = require('../../models/x-unfetter-category');
+mongooseModel['x-unfetter-assessed-object'] = require('../../models/x-unfetter-assessed-object');
 mongooseModel['x-unfetter-assessment-set'] = require('../../models/x-unfetter-assessment-set');
 mongooseModel['x-unfetter-assessment-group'] = require('../../models/x-unfetter-assessment-group');
 mongooseModel['x-unfetter-object-assessment'] = require('../../models/x-unfetter-object-assessment');

--- a/unfetter-discover-api/api/controllers/x_unfetter_categories.js
+++ b/unfetter-discover-api/api/controllers/x_unfetter_categories.js
@@ -1,0 +1,11 @@
+const BaseController = require('./shared/basecontroller');
+
+const controller = new BaseController('x-unfetter-category');
+
+module.exports = {
+    get: controller.get(),
+    getById: controller.getById(),
+    add: controller.add(),
+    update: controller.update(),
+    deleteById: controller.deleteById()
+};

--- a/unfetter-discover-api/api/models/x-unfetter-assessed-object.js
+++ b/unfetter-discover-api/api/models/x-unfetter-assessed-object.js
@@ -1,0 +1,56 @@
+const mongoose = require('mongoose');
+const stixCommons = require('./stix-commons');
+
+const scoreVals = ['S', 'M', 'L', 'N/A', 'N'];
+
+const StixSchema = {
+    id: String,
+    type: {
+        type: String,
+        enum: ['x-unfetter-assessed-object'],
+        default: 'x-unfetter-assessed-object'
+    },
+    assessed_object_ref: String,
+    questions: [
+        {
+            name: {
+                type: String,
+                enum: ['protect'],
+                default: 'protect',
+            },
+            score: {
+                type: String,
+                enum: scoreVals,
+                default: null
+            }
+        },
+        {
+            name: {
+                type: String,
+                enum: ['detect'],
+                default: 'detect',
+            },
+            score: {
+                type: String,
+                enum: scoreVals,
+                default: null
+            }
+        },
+        {
+            name: {
+                type: String,
+                enum: ['respond'],
+                default: 'respond',
+            },
+            score: {
+                type: String,
+                enum: scoreVals,
+                default: null
+            }
+        }
+    ]
+};
+
+const assessedObject = mongoose.model('XUnfetterAssessedObject', stixCommons.makeSchema(StixSchema), 'stix');
+
+module.exports = assessedObject;

--- a/unfetter-discover-api/api/models/x-unfetter-category.js
+++ b/unfetter-discover-api/api/models/x-unfetter-category.js
@@ -1,0 +1,26 @@
+const mongoose = require('mongoose');
+const stixCommons = require('./stix-commons');
+
+const StixSchema = {
+    type: {
+        type: String,
+        enum: ['x-unfetter-category'],
+        default: 'x-unfetter-category'
+    },
+    id: String,
+    created_by_ref: {
+        type: String,
+        required: [true, 'created_by_ref is required']
+    },
+    name: {
+        type: String,
+        required: [true, 'name is required']
+    },
+    description: String,
+    version: Number,
+    assessed_objects: [{ type: mongoose.Schema.Types.ObjectId, ref: 'XUnfetterAssessedObject' }]
+};
+
+const XUnfetterCategory = mongoose.model('XUnfetterCategory', stixCommons.makeSchema(StixSchema), 'stix');
+
+module.exports = XUnfetterCategory;

--- a/unfetter-discover-api/api/models/x-unfetter-object-assessment.js
+++ b/unfetter-discover-api/api/models/x-unfetter-object-assessment.js
@@ -1,8 +1,6 @@
 const mongoose = require('mongoose');
 const stixCommons = require('./stix-commons');
 
-const scoreVals = ['S', 'M', 'L', 'N/A', 'N'];
-
 const StixSchema = {
     created_by_ref: {
         type: String,
@@ -28,48 +26,7 @@ const StixSchema = {
         required: [true, 'is_baseline is required']
     },
     set_ref: [String],
-    assessment_objects: [{
-        _id: false,
-        assessed_object_ref: String,
-        questions: [
-            {
-                name: {
-                    type: String,
-                    enum: ['protect'],
-                    default: 'protect',
-                },
-                score: {
-                    type: String,
-                    enum: scoreVals,
-                    default: null
-                }
-            },
-            {
-                name: {
-                    type: String,
-                    enum: ['detect'],
-                    default: 'detect',
-                },
-                score: {
-                    type: String,
-                    enum: scoreVals,
-                    default: null
-                }
-            },
-            {
-                name: {
-                    type: String,
-                    enum: ['respond'],
-                    default: 'respond',
-                },
-                score: {
-                    type: String,
-                    enum: scoreVals,
-                    default: null
-                }
-            }
-        ]
-    }]
+    assessed_objects: [{ type: mongoose.Schema.Types.ObjectId, ref: 'XUnfetterAssessedObject' }]
 };
 
 const objectAssessment = mongoose.model('XUnfetterObjectAssessment', stixCommons.makeSchema(StixSchema), 'stix');

--- a/unfetter-discover-api/api/swagger/definitions/index.yaml
+++ b/unfetter-discover-api/api/swagger/definitions/index.yaml
@@ -356,6 +356,17 @@ XUnfetterCapabilityJsonApiSingleItem:
 XUnfetterCapability:
   $ref: ./x_unfetter_capabilities/x_unfetter_capability.yaml
 
+XUnfetterCategoryJsonApi:
+  $ref: ./x_unfetter_categories/x_unfetter_category_json_api.yaml
+XUnfetterCategoriesJsonApi:
+  $ref: ./x_unfetter_categories/x_unfetter_categories_json_api.yaml
+XUnfetterCategoryCreateUpdate:
+  $ref: ./x_unfetter_categories/x_unfetter_category_create_update.yaml
+XUnfetterCategoryJsonApiSingleItem:
+  $ref: ./x_unfetter_categories/x_unfetter_category_json_api_single_item.yaml
+XUnfetterCategory:
+  $ref: ./x_unfetter_categories/x_unfetter_category.yaml
+  
 XUnfetterObjectAssessmentJsonApi:
   $ref: ./x_unfetter_object_assessments/x_unfetter_object_assessment_json_api.yaml
 XUnfetterObjectAssessmentsJsonApi:

--- a/unfetter-discover-api/api/swagger/definitions/x_unfetter_categories/x_unfetter_categories_json_api.yaml
+++ b/unfetter-discover-api/api/swagger/definitions/x_unfetter_categories/x_unfetter_categories_json_api.yaml
@@ -1,0 +1,8 @@
+    type: object
+    properties:
+      links:
+        $ref: "#/definitions/Links"
+      data:
+        type: array
+        items:
+          $ref: "#/definitions/XUnfetterCapabilityJsonApi"

--- a/unfetter-discover-api/api/swagger/definitions/x_unfetter_categories/x_unfetter_category.yaml
+++ b/unfetter-discover-api/api/swagger/definitions/x_unfetter_categories/x_unfetter_category.yaml
@@ -1,0 +1,25 @@
+  type: object
+  properties:
+    name:
+      type: string
+    description:
+      type: string
+    version:
+      type: number 
+    created_by_ref:
+      type: string
+      default: "identity-id"
+    created: 
+      type: string
+      format: date-time
+    modified:
+      type: string
+      format: date-time
+    external_references:
+      type: array
+      items:
+        $ref: "#/definitions/ExternalReference"
+    assessed_objects:
+      type: array
+      items:
+        type: object

--- a/unfetter-discover-api/api/swagger/definitions/x_unfetter_categories/x_unfetter_category_create_update.yaml
+++ b/unfetter-discover-api/api/swagger/definitions/x_unfetter_categories/x_unfetter_category_create_update.yaml
@@ -1,0 +1,25 @@
+type: object
+properties:
+  data:
+    type: object
+    properties:
+      attributes:
+        type: object
+        properties:
+          name:
+            type: string
+          description:
+            type: string
+          version:
+            type: number
+          created_by_ref:
+            type: string
+            default: "identity-id"
+          external_references:
+            type: array
+            items:
+              $ref: "#/definitions/ExternalReference"
+          assessed_objects:
+            type: array
+            items:
+              type: object

--- a/unfetter-discover-api/api/swagger/definitions/x_unfetter_categories/x_unfetter_category_json_api.yaml
+++ b/unfetter-discover-api/api/swagger/definitions/x_unfetter_categories/x_unfetter_category_json_api.yaml
@@ -1,0 +1,11 @@
+  type: object
+  properties:
+    id: 
+      type: string
+    type:
+      type: string
+      example: "x-unfetter-category"
+    attributes:
+      $ref: "#/definitions/XUnfetterCategory"
+    links:
+      $ref: "#/definitions/Links"

--- a/unfetter-discover-api/api/swagger/definitions/x_unfetter_categories/x_unfetter_category_json_api_single_item.yaml
+++ b/unfetter-discover-api/api/swagger/definitions/x_unfetter_categories/x_unfetter_category_json_api_single_item.yaml
@@ -1,0 +1,6 @@
+    type: object
+    properties:
+      links:
+        $ref: "#/definitions/Links"
+      data:
+        $ref: "#/definitions/XUnfetterCapabilityJsonApi"

--- a/unfetter-discover-api/api/swagger/paths/index.yaml
+++ b/unfetter-discover-api/api/swagger/paths/index.yaml
@@ -5,6 +5,11 @@
 /v3/x-unfetter-capabilities/{id}:
   $ref: ./x_unfetter_capabilities/capability-by-id.yaml
 
+/v3/x-unfetter-categories:
+  $ref: ./x_unfetter_categories/categories.yaml
+/v3/x-unfetter-categories/{id}:
+  $ref: ./x_unfetter_categories/category-by-id.yaml
+
 /v3/x-unfetter-assessment-sets:
   $ref: ./x_unfetter_assessment_sets/assessment-sets.yaml
 /v3/x-unfetter-assessment-sets/{id}:

--- a/unfetter-discover-api/api/swagger/paths/x_unfetter_categories/categories.yaml
+++ b/unfetter-discover-api/api/swagger/paths/x_unfetter_categories/categories.yaml
@@ -1,0 +1,76 @@
+x-swagger-router-controller: x_unfetter_categories
+get:
+  tags:
+  - STIX-Unfetter Category
+  description: Find all instances of the model matched by filter from the data source.
+  operationId: get
+  produces: 
+  - application/vnd.api+json
+  parameters:
+    - name: filter
+      in: query
+      description: 'Ex: {"stix.name":"Network Firewall"}'
+      required: false
+      type: string
+    - name: sort
+      in: query
+      description: 'Ex: {"stix.name":"1"} or {"stix.name":"-1"}'
+      required: false
+      type: string
+    - name: limit
+      in: query
+      description: 'Ex: 5'
+      required: false
+      type: number
+    - name: skip
+      in: query
+      description: 'Ex: 10'
+      required: false
+      type: number
+    - name: extendedproperties
+      in: query
+      type: boolean
+      description: boolean to include extended stix properties
+    - name: metaproperties
+      in: query
+      type: boolean
+      description: boolean to include extended meta properties
+    - name: project
+      in: query
+      description: 'Ex: {"stix.created_by_ref":1} or {"stix.created_by_ref":0}'
+      required: false
+      type: string
+  responses:
+    "200":
+      description: Success
+      schema:
+        $ref: "#/definitions/XUnfetterCategoriesJsonApi"
+    default:
+      description: Error
+      schema:
+        $ref: "#/definitions/ErrorJsonApi"
+post:
+  tags:
+  - STIX-Unfetter Category
+  description: Create a new instance of the model and persist it into the data source.
+  operationId: add
+  produces: 
+  - application/vnd.api+json
+  consumes:
+  - application/json
+  parameters:
+    - name: data
+      in: body
+      description: Model instance data
+      required: true
+      schema:
+        $ref: "#/definitions/XUnfetterCategoryCreateUpdate"
+  responses:
+    "201":
+      description: Created
+      schema:
+        $ref: "#/definitions/XUnfetterCategoriesJsonApi"
+    default:
+      description: Error
+      schema:
+        $ref: "#/definitions/ErrorJsonApi"

--- a/unfetter-discover-api/api/swagger/paths/x_unfetter_categories/category-by-id.yaml
+++ b/unfetter-discover-api/api/swagger/paths/x_unfetter_categories/category-by-id.yaml
@@ -1,0 +1,97 @@
+x-swagger-router-controller: x_unfetter_categories
+get:
+  tags:
+  - STIX-Unfetter Category
+  description: Returns the details of a category
+  operationId: getById
+  parameters:
+  - name: id
+    in: path
+    description: Model ID
+    type: string
+    required: true
+  - name: extendedproperties
+    in: query
+    type: boolean
+    description: boolean to include extended stix properties
+  - name: metaproperties
+    in: query
+    type: boolean
+    description: boolean to include extended meta properties
+  produces: 
+  - application/json
+  responses:
+    "200":
+      description: Success
+      schema:
+        $ref: "#/definitions/XUnfetterCategoryJsonApiSingleItem"
+    "404":
+      description: Item Not Found
+      schema:
+        $ref: "#/definitions/NotFound"
+    default:
+      description: Error
+      schema:
+        $ref: "#/definitions/DetailedErrorResponse"
+
+patch:
+  tags:
+  - STIX-Unfetter Category
+  description: Patch attributes for a model instance and persist it into the data source.
+  operationId: update
+  produces: 
+  - application/vnd.api+json
+  consumes:
+  - application/json
+  parameters:
+    - name: id
+      in: path
+      description: Model id
+      required: true
+      type: string
+    - name: data
+      in: body
+      description: An object of model property name/value pairs
+      required: true
+      schema:
+        $ref: "#/definitions/XUnfetterCategoryCreateUpdate"
+  responses:
+    "200":
+      description: Success
+      schema:
+        $ref: "#/definitions/XUnfetterCategoryJsonApiSingleItem"
+    "404":
+      description: Item Not Found
+      schema:
+        $ref: "#/definitions/NotFound"
+    default:
+      description: Error
+      schema:
+        $ref: "#/definitions/ErrorJsonApi"
+
+delete:
+  tags:
+  - STIX-Unfetter Category
+  description: Delete a category instance by {{id}} from the data source.
+  operationId: deleteById
+  produces: 
+  - application/vnd.api+json
+  parameters:
+    - name: id
+      in: path
+      description: Model id
+      required: true
+      type: string
+  responses:
+    "200":
+      description: Success
+      schema:
+        $ref: "#/definitions/StixDelete"
+    "404":
+      description: Item Not Found
+      schema:
+        $ref: "#/definitions/NotFound"
+    default:
+      description: Error
+      schema:
+        $ref: "#/definitions/ErrorJsonApi"


### PR DESCRIPTION
supports unfetter-discover/unfetter#955

Pull the unfetter PR `https://github.com/unfetter-discover/unfetter/pull/957` then run this

## problem
create categories crud pages for the new assessments

## changed
add categories endpoints, and refactored the assessed objects across category and object assessment classes

## test
* verify travis
* pull this branch
* restart stack 
* visit the ui, and click the api explorer (may need to refresh your login token, by clicking a new tab from any stale window)
* see the categories endpoints, test them out
* check mongo `db.getCollection('stix').find({'stix.type': 'x-unfetter-category'})`
* try other endpoints, make sure they did'nt break



