### PR TITLE
fix to save assessed objects

### DIFF
--- a/unfetter-discover-api/api/models/x-unfetter-assessed-object.js
+++ b/unfetter-discover-api/api/models/x-unfetter-assessed-object.js
@@ -1,7 +1,7 @@
 const mongoose = require('mongoose');
 const stixCommons = require('./stix-commons');
 
-const scoreVals = ['S', 'M', 'L', 'N/A', 'N'];
+const scoreVals = ['L', 'M', 'S', 'N/A', 'N'];
 
 const StixSchema = {
     id: String,
@@ -15,32 +15,8 @@ const StixSchema = {
         {
             name: {
                 type: String,
-                enum: ['protect'],
-                default: 'protect',
-            },
-            score: {
-                type: String,
-                enum: scoreVals,
-                default: null
-            }
-        },
-        {
-            name: {
-                type: String,
-                enum: ['detect'],
-                default: 'detect',
-            },
-            score: {
-                type: String,
-                enum: scoreVals,
-                default: null
-            }
-        },
-        {
-            name: {
-                type: String,
-                enum: ['respond'],
-                default: 'respond',
+                enum: ['mitigate', 'indicate', 'respond'],
+                default: null,
             },
             score: {
                 type: String,
@@ -51,6 +27,10 @@ const StixSchema = {
     ]
 };
 
-const assessedObject = mongoose.model('XUnfetterAssessedObject', stixCommons.makeSchema(StixSchema), 'stix');
+const xunfetterAssessObject = StixSchema;
+const assessedObject = mongoose.model('XUnfetterAssessedObject', xunfetterAssessObject, 'stix');
 
-module.exports = assessedObject;
+module.exports = {
+    assessedObject,
+    xunfetterAssessObject,
+};

--- a/unfetter-discover-api/api/models/x-unfetter-category.js
+++ b/unfetter-discover-api/api/models/x-unfetter-category.js
@@ -1,5 +1,6 @@
 const mongoose = require('mongoose');
 const stixCommons = require('./stix-commons');
+const xunfetterAssessObject = require('./x-unfetter-assessed-object').xunfetterAssessObject;
 
 const StixSchema = {
     type: {
@@ -18,7 +19,7 @@ const StixSchema = {
     },
     description: String,
     version: Number,
-    assessed_objects: [{ type: mongoose.Schema.Types.ObjectId, ref: 'XUnfetterAssessedObject' }]
+    assessed_objects: [xunfetterAssessObject]
 };
 
 const XUnfetterCategory = mongoose.model('XUnfetterCategory', stixCommons.makeSchema(StixSchema), 'stix');


### PR DESCRIPTION
supports unfetter-discover/unfetter#955

# problem
need to save new categories
currently the assessed objects is failing

# solution
use a nested shared schema and not a ref object in mongoose

# test
* pull this pr
* verify travis
* visit the api swagger page
* try out the post and confirm this value works
```
{
    "data": {
        "attributes": {
            "version": 2,
            "valid_from": "2018-04-17T20:14:05.126Z",
            "created": "2018-04-17T20:14:05.126Z",
            "type": "x-unfetter-capability-category",
            "assessed_objects": [
                {
                    "type": "x-unfetter-assessed-object",
                    "questions": [
                        {
                            "type": "x-unfetter-question",
                            "score": "M",
                            "name": "mitigate"
                        },
                        {
                            "type": "x-unfetter-question",
                            "score": "M",
                            "name": "indicate"
                        },
                        {
                            "type": "x-unfetter-question",
                            "score": "S",
                            "name": "respond"
                        }
                    ],
                    "assessed_object_ref": "attack-pattern--dcaa092b-7de9-4a21-977f-7fcb77e89c48"
                }
            ],
            "created_by_ref": "identity--e240b257-5c42-402e-a0e8-7b81ecc1c09a",
            "name": "test1",
            "description": "test1"
        }
    }
}
```