### PR TITLE
IP Geo service on backend

### DIFF
--- a/unfetter-discover-api/api/controllers/ipgeo.js
+++ b/unfetter-discover-api/api/controllers/ipgeo.js
@@ -1,0 +1,172 @@
+const fetch = require('node-fetch');
+const ipregex = require('ip-regex');
+
+/**
+ * Uses the Builder pattern.
+ */
+class RequestError {
+
+    static create() {
+        let re = new RequestError();
+        re.err = {
+            status: 500,
+            source: '',
+            title: '',
+            errors: []
+        };
+        return re;
+    }
+
+    addError(code = '', message = 'An unknown error has occurred.') {
+        this.err.errors.push({
+            code: code,
+            message: message,
+        });
+        return this;
+    }
+
+    status(status = 500) {
+        this.status = status;
+        return this;
+    }
+
+    source(source = '') {
+        this.source = source;
+        return this;
+    }
+
+    title(title = '') {
+        this.title = title;
+        return this;
+    }
+
+    code(code = '') {
+        this.current().code = code;
+        return this;
+    }
+
+    message(message = '') {
+        this.current().message = message;
+        return this;
+    }
+
+    current() {
+        if (this.err.errors.length) {
+            return this.err.errors.slice(-1)[0];
+        } else {
+            return this.addError();
+        }
+    }
+
+    build() { return this.err }
+
+}
+
+class IPGeoProvider {
+    constructor(id, url, active = true, batchSeparator = null) {
+        this.id = id;
+        this.url = url;
+        this.active = active;
+        this.batchSeparator = batchSeparator;
+        this.setKey = (req) => {};
+    }
+
+    withHeaderKey(header, key) {
+        this.setKey = (req) => {
+            request.headers = {header: header, key: String(key)}
+        };
+        return this;
+    }
+
+    withQueryParamKey(param, key) {
+        this.setKey = (req) => {
+            req.uri += (req.uri.indexOf('?') > 0) ? '&' : '?';
+            req.uri += String(param) + '=' + String(key);
+        };
+        return this;
+    }
+}
+
+/*
+ * TODO Need to find a way to add this information to the system configuration (not something a user needs to see).
+ *      If we do so, we can also do more to add the optional/required personal keys that some providers require, or
+ *      that can be purchased.
+ */
+const IPGEO_PROVIDERS = [
+    // another free service allows up to 1500 requests per day, can be bulk(?)
+    new IPGeoProvider('ipdata.co', 'https://api.ipdata.co/*'),
+
+    // free-version service allows up to 1000 requests per day, no bulk queries
+    new IPGeoProvider('ipapi.co', 'https://ipapi.co/*/json/'),
+
+    // free-version service allows up to 10,000 requests per MONTH (bah!), can be bulk,
+    // and being replaced by newer (still free) service that requires sign-up by 1 July 2018
+    new IPGeoProvider('freegeoip', 'https://freegeoip.net/json/*', false),
+
+    // new endpoint for freegeoip with personal key ()
+    new IPGeoProvider('ipstack.com', 'http://api.ipstack.com/*', true, ',')
+            .withQueryParamKey('access_key', '64a9512c200c1edd5b5b521a441f0eff'),
+];
+
+/**
+ * @param {IPGeoProvider} provider 
+ * @param {String[]} ip IP address to look up
+ */
+function queryProviders(providers, ip, res, error = RequestError.create()) {
+    const provider = providers.shift();
+    if (!provider) {
+        return res.status(500).json(error.build());
+    }
+
+    const request = {
+        uri: provider.url.replace('*', ip),
+        headers: {
+            'Accept': 'application/json',
+        },
+    }
+    provider.setKey(request);
+
+    const timeout = 1000 * 5; // millis
+    fetch(request.uri, {
+        headers: request.headers,
+        method: 'GET',
+        timeout
+    }).then(response => response
+        .json())
+        .then(json => {
+            return res.status(200).json({success: true, provider: provider.id, ...json});
+        })
+        .catch(ex => {
+            error.addError().code(provider.id).message(ex);
+            queryProviders(providers, ip, res, error);
+        });
+}
+
+const lookup = (req, res) => {
+    if (!req || !req.swagger || !req.swagger.params) {
+        return res.status(500).json(RequestError.create().addError().build());
+    }
+
+    const ip = req.swagger.params.ip;
+    if (!ip || !ip.value) {
+        return res.status(400).json(RequestError.create().status(400).title('No IP Address Provided')
+                .message('You must provide an IP address to locate.').build());
+    }
+    if (!ipregex().test(ip.value)) {
+        return res.status(400).json(RequestError.create().status(400).title('Invalid IP Address Provided')
+                .message(`The given value is not a valid IP address: ${ip}`).build());
+    }
+
+    const activeProviders = IPGEO_PROVIDERS.filter(provider => provider.active);
+    if (activeProviders.length === 0) {
+        return res.status(503).json(RequestError.create().status(503).title('No IP-geo providers')
+                .message('There are no active providers for geolocation services in our current configuration.  ' +
+                        'Please ask administrators to add new providers.').build())
+    }
+
+    queryProviders(activeProviders, ip.value, res);
+};
+
+module.exports = {
+    lookup
+};

--- a/unfetter-discover-api/api/controllers/ipgeo.js
+++ b/unfetter-discover-api/api/controllers/ipgeo.js
@@ -7,7 +7,7 @@ const ipregex = require('ip-regex');
 class RequestError {
 
     static create() {
-        let re = new RequestError();
+        const re = new RequestError();
         re.err = {
             status: 500,
             title: '',
@@ -30,11 +30,7 @@ class RequestError {
     }
 
     addError(source = undefined, code = undefined, message = 'An unknown error has occurred.') {
-        this.err.errors.push({
-            code: code,
-            source: source,
-            message: message,
-        });
+        this.err.errors.push({ code, source, message, });
         console.log('added error', this);
         return this;
     }
@@ -81,17 +77,12 @@ class IPGeoProvider {
     }
 
     withHeaderKey(header, key) {
-        this.setKey = (req) => {
-            request.headers = {header: header, key: String(key)}
-        };
+        this.setKey = req => req.headers = { header, key, };
         return this;
     }
 
     withQueryParamKey(param, key) {
-        this.setKey = (req) => {
-            req.uri += (req.uri.indexOf('?') > 0) ? '&' : '?';
-            req.uri += String(param) + '=' + String(key);
-        };
+        this.setKey = req => req.uri = `${req.uri}${(req.uri.indexOf('?') > 0) ? '&' : '?'}${param}=${key}`;
         return this;
     }
 }
@@ -118,7 +109,7 @@ const IPGEO_PROVIDERS = [
 ];
 
 /**
- * @param {IPGeoProvider} provider 
+ * @param {IPGeoProvider} provider
  * @param {String[]} ip IP address to look up
  */
 function queryProviders(providers, ip, res, error = RequestError.create()) {
@@ -130,9 +121,9 @@ function queryProviders(providers, ip, res, error = RequestError.create()) {
     const request = {
         uri: provider.url.replace('*', ip),
         headers: {
-            'Accept': 'application/json',
+            Accept: 'application/json',
         },
-    }
+    };
     provider.setKey(request);
 
     const timeout = 1000 * 5; // millis
@@ -142,9 +133,7 @@ function queryProviders(providers, ip, res, error = RequestError.create()) {
         timeout
     }).then(response => response
         .json())
-        .then(json => {
-            return res.status(200).json({success: true, provider: provider.id, ...json});
-        })
+        .then(json => res.status(200).json({ success: true, provider: provider.id, ...json }))
         .catch(ex => {
             error.addError().source(provider.id).message(ex);
             queryProviders(providers, ip, res, error);
@@ -161,17 +150,20 @@ const lookup = (req, res) => {
     const ip = req.swagger.params.ip;
     if (!ip || !ip.value) {
         return res.status(400).json(RequestError.create().status(400).title('No IP Address Provided')
-            .message('You must provide an IP address to locate.').build());
+            .message('You must provide an IP address to locate.')
+            .build());
     }
     console.log('testing ip value', ip.value);
     try {
         if (!ipregex().test(ip.value)) {
             return res.status(400).json(RequestError.create().status(400).title('Invalid IP Address Provided')
-                .message(`The given value is not a valid IP address: ${ip.value}`).build());
+                .message(`The given value is not a valid IP address: ${ip.value}`)
+                .build());
         }
     } catch (ex) {
         return res.status(500).json(RequestError.create().status(500).title('Error performing IP check')
-            .message(`Could not perform IP validation: ${ex}`).build());
+            .message(`Could not perform IP validation: ${ex}`)
+            .build());
     }
 
     console.log('starting queries');
@@ -179,7 +171,8 @@ const lookup = (req, res) => {
     if (activeProviders.length === 0) {
         return res.status(503).json(RequestError.create().status(503).title('No IP-geo providers')
             .message('There are no active providers for geolocation services in our current configuration.  ' +
-                    'Please ask administrators to add new providers.').build())
+                    'Please ask administrators to add new providers.')
+            .build())
     }
 
     queryProviders(activeProviders, ip.value, res);

--- a/unfetter-discover-api/api/controllers/ipgeo.js
+++ b/unfetter-discover-api/api/controllers/ipgeo.js
@@ -13,43 +13,36 @@ class RequestError {
             title: '',
             errors: []
         };
-        console.log('created request error object', re);
         return re;
     }
 
     status(status) {
         this.err.status = status;
-        console.log('set status', this);
         return this;
     }
 
     title(title = '') {
         this.err.title = title;
-        console.log('set title', this);
         return this;
     }
 
     addError(source = undefined, code = undefined, message = 'An unknown error has occurred.') {
         this.err.errors.push({ code, source, message, });
-        console.log('added error', this);
         return this;
     }
 
     code(code = '') {
         this.current().code = code;
-        console.log('set code', this);
         return this;
     }
 
     source(source) {
         this.current().source = source;
-        console.log('set source', this);
         return this;
     }
 
     message(message = '') {
         this.current().message = message;
-        console.log('set message', this);
         return this;
     }
 
@@ -61,7 +54,6 @@ class RequestError {
     }
 
     build() {
-        console.log('final', this.err);
         return this.err;
     }
 
@@ -137,7 +129,7 @@ function queryProviders(providers, ip, res, error = RequestError.create()) {
         timeout
     }).then(response => response
         .json())
-        .then(json => res.status(200).json({ success: true, provider: provider.id, ...json }))
+        .then(json => res.status(200).json({ data: { success: true, provider: provider.id, ...json } }))
         .catch(ex => {
             error.addError().source(provider.id).message(ex);
             queryProviders(providers, ip, res, error);
@@ -146,18 +138,15 @@ function queryProviders(providers, ip, res, error = RequestError.create()) {
 
 const lookup = (req, res) => {
     if (!req || !req.swagger || !req.swagger.params) {
-        console.log('no req or swagger or params object');
         return res.status(500).json(RequestError.create().addError().build());
     }
 
-    console.log('pulling ip value');
     const ip = req.swagger.params.ip;
     if (!ip || !ip.value) {
         return res.status(400).json(RequestError.create().status(400).title('No IP Address Provided')
             .message('You must provide an IP address to locate.')
             .build());
     }
-    console.log('testing ip value', ip.value);
     try {
         if (!ipregex().test(ip.value)) {
             return res.status(400).json(RequestError.create().status(400).title('Invalid IP Address Provided')
@@ -170,7 +159,6 @@ const lookup = (req, res) => {
             .build());
     }
 
-    console.log('starting queries');
     const activeProviders = IPGEO_PROVIDERS.filter(provider => provider.active);
     if (activeProviders.length === 0) {
         return res.status(503).json(RequestError.create().status(503).title('No IP-geo providers')

--- a/unfetter-discover-api/api/controllers/ipgeo.js
+++ b/unfetter-discover-api/api/controllers/ipgeo.js
@@ -73,16 +73,20 @@ class IPGeoProvider {
         this.url = url;
         this.active = active;
         this.batchSeparator = batchSeparator;
-        this.setKey = (req) => {};
+        this.setKey = req => {};
     }
 
     withHeaderKey(header, key) {
-        this.setKey = req => req.headers = { header, key, };
+        this.setKey = req => {
+            req.headers = { header, key, };
+        };
         return this;
     }
 
     withQueryParamKey(param, key) {
-        this.setKey = req => req.uri = `${req.uri}${(req.uri.indexOf('?') > 0) ? '&' : '?'}${param}=${key}`;
+        this.setKey = req => {
+            req.uri = `${req.uri}${(req.uri.indexOf('?') > 0) ? '&' : '?'}${param}=${key}`;
+        };
         return this;
     }
 }
@@ -172,7 +176,7 @@ const lookup = (req, res) => {
         return res.status(503).json(RequestError.create().status(503).title('No IP-geo providers')
             .message('There are no active providers for geolocation services in our current configuration.  ' +
                     'Please ask administrators to add new providers.')
-            .build())
+            .build());
     }
 
     queryProviders(activeProviders, ip.value, res);

--- a/unfetter-discover-api/api/swagger/paths/index.yaml
+++ b/unfetter-discover-api/api/swagger/paths/index.yaml
@@ -182,6 +182,9 @@
 /config/{id}:
   $ref: ./config/config_by_id.yaml
 
+/lookup:
+  $ref: ./ipgeo/ipgeo.yaml
+
 /latest/threat-reports:
   $ref: ./latest/latest-threat-report.yaml
 /latest/threat-reports/creator/{id}:

--- a/unfetter-discover-api/api/swagger/paths/ipgeo/ipgeo.yaml
+++ b/unfetter-discover-api/api/swagger/paths/ipgeo/ipgeo.yaml
@@ -1,0 +1,23 @@
+x-swagger-router-controller: ipgeo
+get:
+  tags:
+  - Lookup
+  description: Find the location of the given IP address.
+  operationId: lookup
+  produces: 
+  - application/vnd.api+json  
+  parameters:
+    - name: ip
+      in: query
+      description: 'Ex: 8.8.8.8'
+      required: true
+      type: string
+  responses:
+    "200":
+      description: Success
+      schema:
+        $ref: "#/definitions/ConfigJsonApi"
+    default:
+      description: Error
+      schema:
+        $ref: "#/definitions/ErrorJsonApi"

--- a/unfetter-discover-api/package-lock.json
+++ b/unfetter-discover-api/package-lock.json
@@ -3493,6 +3493,11 @@
       "integrity": "sha1-y8NcYu7uc/Gat7EKgBURQBr8D5A=",
       "dev": true
     },
+    "ip-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-3.0.0.tgz",
+      "integrity": "sha512-T8wDtjy+Qf2TAPDQmBp0eGKJ8GavlWlUnamr3wRn6vvdZlKVuJXXMlSncYFRYgVHOM3If5NR1H4+OvVQU9Idvg=="
+    },
     "is-binary-path": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",

--- a/unfetter-discover-api/package.json
+++ b/unfetter-discover-api/package.json
@@ -12,6 +12,7 @@
     "express": "^4.12.3",
     "express-session": "^1.15.6",
     "https-proxy-agent": "^2.1.0",
+    "ip-regex": "^3.0.0",
     "jsonwebtoken": "^8.0.1",
     "lodash": "^4.17.4",
     "mongoose": "^4.9.9",


### PR DESCRIPTION
Supports unfetter-discover/unfetter#949.

Adds an API endpoint (/lookup) for querying ipgeo locations. The UI will be changed in a separate PR, which is not needed for this PR.

You will likely need to get rid of the discover-api in the stack before testing (`docker rmi unfetter-discover-api`).

Easiest way to test is to go to the API documentation page, scroll down to the `lookup` endpoint, and test a few IP addresses (and non-IP addresses to feel like a real QA person).