### PR TITLE
Issue 977

### DIFF
--- a/unfetter-discover-api/api/controllers/x_unfetter_assessment_sets.js
+++ b/unfetter-discover-api/api/controllers/x_unfetter_assessment_sets.js
@@ -44,7 +44,7 @@ const latestAssessmentSetPromise = (query, req, res) => {
 };
 
 /**
- * @description fetch assessment sets for given creator id, sort base on last modified
+ * @description fetch assessment sets for given creator id, sort based on last modified
  */
 const latestAssessmentSetsByCreatorId = (req, res) => {
     const id = req.swagger.params.creatorId ? req.swagger.params.creatorId.value : '';
@@ -110,8 +110,8 @@ const latestAssessmentSetsByCreatorId = (req, res) => {
 };
 
 /**
- * @description fetch assessments whereby the created_by_ref is in the current users organizations
- *  , sort base on last modified
+ * @description fetch baselines (assessment sets) whereby the created_by_ref is in the current users organizations
+ *  , sort based on last modified
  */
 const latestAssessmentSets = (req, res) => {
     const query = parser.dbQueryParams(req);

--- a/unfetter-discover-api/api/controllers/x_unfetter_assessment_sets.js
+++ b/unfetter-discover-api/api/controllers/x_unfetter_assessment_sets.js
@@ -110,7 +110,7 @@ const latestAssessmentSetsByCreatorId = (req, res) => {
 };
 
 /**
- * @description fetch baselines (assessment sets) whereby the created_by_ref is in the current users organizations
+ * @description fetch baselines (assessment sets) whereby the created_by_ref is in the current user's organizations
  *  , sort based on last modified
  */
 const latestAssessmentSets = (req, res) => {

--- a/unfetter-discover-api/api/controllers/x_unfetter_assessment_sets.js
+++ b/unfetter-discover-api/api/controllers/x_unfetter_assessment_sets.js
@@ -1,11 +1,194 @@
+const modelFactory = require('./shared/modelFactory');
 const BaseController = require('./shared/basecontroller');
+const SecurityHelper = require('../helpers/security_helper');
+const parser = require('../helpers/url_parser');
 
 const controller = new BaseController('x-unfetter-assessment-set');
+const aggregationModel = modelFactory.getAggregationModel('stix');
+
+/**
+ * @description execute the given query as a mongo aggregate pipeline, write to the given response object
+ * @param {object} query - mongo aggregate object pipeline object
+ * @param {Request} req
+ * @param {Response} res
+ */
+const latestAssessmentSetPromise = (query, req, res) => {
+    Promise.resolve(aggregationModel.aggregate(query))
+        .then(results => {
+            const requestedUrl = req.originalUrl;
+
+            const mappedResults = results
+                .map(r => {
+                    const retVal = { ...r };
+                    retVal.id = r.stix.id;
+                    return retVal;
+                });
+
+            return res.status(200).json({
+                links: {
+                    self: requestedUrl,
+                },
+                data: mappedResults
+            });
+        })
+        .catch(err => // eslint-disable-line no-unused-vars
+            res.status(500).json({
+                errors: [{
+                    status: 500,
+                    source: '',
+                    title: 'Error',
+                    code: '',
+                    detail: `Error getting latest assessment sets:\n${err}`
+                }]
+            }));
+};
+
+/**
+ * @description fetch assessment sets for given creator id, sort base on last modified
+ */
+const latestAssessmentSetsByCreatorId = (req, res) => {
+    const id = req.swagger.params.creatorId ? req.swagger.params.creatorId.value : '';
+
+    // aggregate pipeline
+    //  sort on last modified
+    const latestAssessmentSetsByCreatorIdChild = [
+        {
+            $match: {
+                creator: id,
+                'stix.type': 'x-unfetter-assessment-set'
+            }
+        },
+        {
+            $project: {
+                'stix.assessment_sets': {
+                    $arrayElemAt: ['$stix.assessment_sets', 0]
+                },
+                'stix.id': 1,
+                'stix.name': 1,
+                'stix.modified': 1,
+                'stix.created_by_ref': 1,
+                creator: 1
+            }
+        },
+        {
+            $group: {
+                _id: '$stix.id',
+                id: {
+                    $push: '$stix.id'
+                },
+                name: {
+                    $first: '$stix.name'
+                },
+                modified: {
+                    $max: '$stix.modified'
+                },
+                creator: {
+                    $first: '$creator'
+                },
+                created_by_ref: {
+                    $first: '$stix.created_by_ref'
+                },
+                stix: {
+                    $addToSet: {
+                        type: '$stix.assessment_sets.stix.type',
+                        id: '$stix.id'
+                    }
+                }
+            }
+        },
+        {
+            $unwind: '$stix'
+        },
+        {
+            $sort: {
+                modified: -1
+            }
+        }
+    ];
+
+    latestAssessmentSetPromise(latestAssessmentSetsByCreatorIdChild, req, res);
+};
+
+/**
+ * @description fetch assessments whereby the created_by_ref is in the current users organizations
+ *  , sort base on last modified
+ */
+const latestAssessmentSets = (req, res) => {
+    const query = parser.dbQueryParams(req);
+    if (query.error) {
+        return res.status(400).json({
+            errors: [{
+                status: 400, source: '', title: 'Error', code: '', detail: query.error
+            }]
+        });
+    }
+
+    const matcherQuery = SecurityHelper.applySecurityFilter(Object.assign({ 'stix.type': 'x-unfetter-assessment-set' }, query.filter), req.user);
+    const matchStage = {
+        $match: matcherQuery
+    };
+
+    // aggregate pipeline
+    //  sort on last modified
+    const latestAssessmentSetsByCreatedByRefs = [
+        matchStage,
+        {
+            $project: {
+                'stix.assessment_sets': {
+                    $arrayElemAt: ['$stix.assessment_sets', 0]
+                },
+                'stix.id': 1,
+                'stix.name': 1,
+                'stix.modified': 1,
+                'stix.created_by_ref': 1,
+                creator: 1
+            }
+        },
+        {
+            $group: {
+                _id: '$stix.id',
+                id: {
+                    $push: '$stix.id'
+                },
+                name: {
+                    $first: '$stix.name'
+                },
+                modified: {
+                    $max: '$stix.modified'
+                },
+                creator: {
+                    $first: '$creator'
+                },
+                created_by_ref: {
+                    $first: '$stix.created_by_ref'
+                },
+                stix: {
+                    $addToSet: {
+                        type: '$stix.assessment_sets.stix.type',
+                        id: '$stix.id'
+                    }
+                }
+            }
+        },
+        {
+            $unwind: '$stix'
+        },
+        {
+            $sort: {
+                modified: -1
+            }
+        }
+    ];
+
+    latestAssessmentSetPromise(latestAssessmentSetsByCreatedByRefs, req, res);
+};
 
 module.exports = {
     get: controller.get(),
     getById: controller.getById(),
     add: controller.add(),
     update: controller.update(),
-    deleteById: controller.deleteById()
+    deleteById: controller.deleteById(),
+    latestAssessmentSetsByCreatorId,
+    latestAssessmentSets,
 };

--- a/unfetter-discover-api/api/swagger/paths/index.yaml
+++ b/unfetter-discover-api/api/swagger/paths/index.yaml
@@ -14,6 +14,11 @@
   $ref: ./x_unfetter_assessment_sets/assessment-sets.yaml
 /v3/x-unfetter-assessment-sets/{id}:
   $ref: ./x_unfetter_assessment_sets/assessment-set-by-id.yaml
+/v3/x-unfetter-assessment-sets/latest/{creatorId}:
+  $ref: ./x_unfetter_assessment_sets/latest-assessment-sets-by-creator.yaml
+/v3/x-unfetter-assessment-sets/latest:
+  $ref: ./x_unfetter_assessment_sets/latest-assessment-sets.yaml
+
 
 /v3/x-unfetter-assessment-groups:
   $ref: ./x_unfetter_assessment_groups/assessment-groups.yaml

--- a/unfetter-discover-api/api/swagger/paths/x_unfetter_assessment_sets/latest-assessment-sets-by-creator.yaml
+++ b/unfetter-discover-api/api/swagger/paths/x_unfetter_assessment_sets/latest-assessment-sets-by-creator.yaml
@@ -2,7 +2,6 @@ x-swagger-router-controller: x_unfetter_assessment_sets
 get:
   tags:
   - STIX-Unfetter Assessment Set
-  - Dashboard-Unfetter Baseline
   description: Find all instances of assessment sets from creator, sorted by last modified
   operationId: latestAssessmentSetsByCreatorId
   parameters:

--- a/unfetter-discover-api/api/swagger/paths/x_unfetter_assessment_sets/latest-assessment-sets-by-creator.yaml
+++ b/unfetter-discover-api/api/swagger/paths/x_unfetter_assessment_sets/latest-assessment-sets-by-creator.yaml
@@ -1,0 +1,25 @@
+x-swagger-router-controller: x_unfetter_assessment_sets
+get:
+  tags:
+  - STIX-Unfetter Assessment Set
+  - Dashboard-Unfetter Baseline
+  description: Find all instances of assessment sets from creator, sorted by last modified
+  operationId: latestAssessmentSetsByCreatorId
+  parameters:
+  - name: creatorId
+    in: path
+    description: creator id
+    type: string
+    required: true
+    format: JSON
+  produces: 
+  - application/json
+  responses:
+    "200":
+      description: Success
+      schema:
+        type: object     
+    default:
+      description: Error
+      schema:
+        $ref: "#/definitions/DetailedErrorResponse"

--- a/unfetter-discover-api/api/swagger/paths/x_unfetter_assessment_sets/latest-assessment-sets.yaml
+++ b/unfetter-discover-api/api/swagger/paths/x_unfetter_assessment_sets/latest-assessment-sets.yaml
@@ -1,0 +1,18 @@
+x-swagger-router-controller: x_unfetter_assessment_sets
+get:
+  tags:
+  - STIX-Unfetter Assessment Set
+  - Dashboard-Unfetter Baseline
+  description: Find all instances of assessment sets (baselines), sorted by last modified, restrict to current user and RUN_MODE rules
+  operationId: latestAssessmentSets
+  produces: 
+  - application/json
+  responses:
+    "200":
+      description: Success
+      schema:
+        type: object
+    default:
+      description: Error
+      schema:
+        $ref: "#/definitions/DetailedErrorResponse"

--- a/unfetter-discover-api/api/swagger/paths/x_unfetter_assessment_sets/latest-assessment-sets.yaml
+++ b/unfetter-discover-api/api/swagger/paths/x_unfetter_assessment_sets/latest-assessment-sets.yaml
@@ -2,7 +2,6 @@ x-swagger-router-controller: x_unfetter_assessment_sets
 get:
   tags:
   - STIX-Unfetter Assessment Set
-  - Dashboard-Unfetter Baseline
   description: Find all instances of assessment sets (baselines), sorted by last modified, restrict to current user and RUN_MODE rules
   operationId: latestAssessmentSets
   produces: 

--- a/unfetter-discover-api/api/swagger/paths/x_unfetter_assessments/assessed-objects.yaml
+++ b/unfetter-discover-api/api/swagger/paths/x_unfetter_assessments/assessed-objects.yaml
@@ -2,7 +2,6 @@ x-swagger-router-controller: x_unfetter_assessments
 get:
   tags:
   - STIX-Unfetter Assessment
-  - Dashboard-Unfetter Assessment
   description: Returns the details of an assessment report
   operationId: assessedObjects
   parameters:


### PR DESCRIPTION
Adds in routes for 'latest' baseline (assessment set) in a given org and in the user's org.

To Test:
checkout branch and restart stack
go to API Explorer page
Test /v3/x-unfetter-assessment-sets/latest should get back all baselines (assessment sets) for your org.
I would say test /v3/x-unfetter-assessment-sets/latest/{creatorId}, but this does not appear to be working as expected for any of the routes like this. All return no data. I will follow up on that with a separate issue.
