### PR TITLE
add metaproperties to assessments call

### DIFF
--- a/unfetter-discover-api/api/swagger/paths/x_unfetter_assessments/assessments.yaml
+++ b/unfetter-discover-api/api/swagger/paths/x_unfetter_assessments/assessments.yaml
@@ -32,6 +32,14 @@ get:
       description: 'Ex: {"stix.created_by_ref":1} or {"stix.created_by_ref":0}'
       required: false
       type: string
+    - name: extendedproperties
+      in: query
+      type: boolean
+      description: boolean to include extended stix properties
+    - name: metaproperties
+      in: query
+      type: boolean
+      description: boolean to include extended meta properties
   
   responses:
     "200":


### PR DESCRIPTION
## problem
assessments get call does not return meta properties, even if requested in the GET request

## changes
add metaproperties switch to swagger definition

## test
verify travis
pull this branch
restart stack
visit the swagger page

GET `/x-unfetter-assessments/`
Enter in the filter box
```
{ "metaProperties.rollupId":"925b19cc-6dfa-4b12-a20c-992e2f999b7b" }
```
Select true to return metaproperties

Verify meta is returned


