### PR TITLE
Issue 1080 (Removed obsolete attributes is_baseline and set_ref on object assessments)

### DIFF
--- a/unfetter-discover-api/api/models/x-unfetter-object-assessment.js
+++ b/unfetter-discover-api/api/models/x-unfetter-object-assessment.js
@@ -21,11 +21,6 @@ const StixSchema = {
         type: String,
         required: [true, 'object_ref is required']
     },
-    is_baseline: {
-        type: Boolean,
-        required: [true, 'is_baseline is required']
-    },
-    set_ref: [String],
     assessed_objects: [{ type: mongoose.Schema.Types.ObjectId, ref: 'XUnfetterAssessedObject' }]
 };
 

--- a/unfetter-discover-api/api/swagger/definitions/x_unfetter_object_assessments/x_unfetter_object_assessment.yaml
+++ b/unfetter-discover-api/api/swagger/definitions/x_unfetter_object_assessments/x_unfetter_object_assessment.yaml
@@ -7,18 +7,12 @@
         type: string
       object_ref:
         type: string
-      is_baseline:
-        type: boolean
       created: 
         type: string
         format: date-time
       modified:
         type: string
         format: date-time
-      set_ref:
-        type: array
-        items:
-          type: string
       assessment_objects:
         type: array
         items:

--- a/unfetter-discover-api/api/swagger/definitions/x_unfetter_object_assessments/x_unfetter_object_assessment_create_update.yaml
+++ b/unfetter-discover-api/api/swagger/definitions/x_unfetter_object_assessments/x_unfetter_object_assessment_create_update.yaml
@@ -13,18 +13,12 @@ properties:
             type: string
           object_ref:
             type: string
-          is_baseline:
-            type: boolean
           created: 
             type: string
             format: date-time
           modified:
             type: string
             format: date-time
-          set_ref:
-            type: array
-            items:
-              type: string
           assessment_objects:
             type: array
             items:


### PR DESCRIPTION
Fixes unfetter-discover/unfetter#1080

`is_baseline` and `set_ref` were obsoleted on the x-unfetter-object-assessment object through evolution of the design of assessments 3.0.  A baseline is an assessment_set, and references between assessment set and object assessment are maintained in the assessment set.

## To test:
1. Pull this PR
2. Stop the stack and compile swagger for unfetter-discover-api:  `npm run compileswagger`
3. Remove images for unfetter-discover-api
4. Start up the stack
5. Access API and verify is_baseline and set_ref are not part of x-unfetter-object-assessment in the example JSON for POST
