### PR TITLE
processor correctly saves collection id from taxii

### DIFF
--- a/unfetter-discover-processor/src/services/taxii-client.service.ts
+++ b/unfetter-discover-processor/src/services/taxii-client.service.ts
@@ -106,7 +106,7 @@ export default function getTaxiiData(localArgv: any): Promise<IUFStix[]> {
             if (!roots.length) {
                 reject('Can not find roots');
             } else {
-                let allObjects: IStix[] = [];
+                let allObjects: IUFStix[] = [];
                 for (const root of roots) {
                     // Get collections by root
                     const allCollectionIds = await TaxiiClient.getCollections(taxiiUrl, root);
@@ -115,11 +115,16 @@ export default function getTaxiiData(localArgv: any): Promise<IUFStix[]> {
 
                     for (const collectionId of collectionIds) {
                         // Get objects by collection
-                        const objects = await TaxiiClient.getObjects(taxiiUrl, root, collectionId);
-                        allObjects = allObjects.concat(objects);
+                        const objects: IStix[] = await TaxiiClient.getObjects(taxiiUrl, root, collectionId);
+                        allObjects = allObjects
+                            .concat(
+                                objects
+                                    .map(StixToUnfetterAdapater.stixToUnfetterStix)
+                                    .map((obj) => ({ ...obj, metaProperties: { collection: [ collectionId ] }}))
+                            );
                     }
                 }
-                resolve(allObjects.map(StixToUnfetterAdapater.stixToUnfetterStix));
+                resolve(allObjects);
             }
         } catch (error) {
             reject(error);


### PR DESCRIPTION
There is not an easy way to test the TAXII mapping.  Drop STIX collection via `db.getCollection('stix').remove({})`, restart stack, and confirm that the processor ran correctly.

fixes unfetter-discover/unfetter#1083