### PR TITLE
fix for unfetter-discover/unfetter#1095

### DIFF
--- a/unfetter-discover-api/api/controllers/x_unfetter_assessments.js
+++ b/unfetter-discover-api/api/controllers/x_unfetter_assessments.js
@@ -214,27 +214,30 @@ const riskPerKillChain = controller.getByIdCb((err, result, req, res, id) => { /
                 assessment = assessment.toObject().stix;
             }
 
-            const indicators = results[0]
-                .filter(doc => doc !== undefined)
-                .map(doc => ({
-                    ...doc.toObject().stix,
-                    ...doc.toObject().metaProperties
-                }));
-            const indicatorRisks = [];
-            const sensors = results[1]
-                .filter(doc => doc !== undefined)
-                .map(doc => ({
-                    ...doc.toObject().stix,
-                    ...doc.toObject().metaProperties
-                }));
-            const sensorRisks = [];
-            const courseOfActions = results[2]
+            const courseOfActions = results[0]
                 .filter(doc => doc !== undefined)
                 .map(doc => ({
                     ...doc.toObject().stix,
                     ...doc.toObject().metaProperties
                 }));
             const coaRisks = [];
+
+            const indicators = results[1]
+                .filter(doc => doc !== undefined)
+                .map(doc => ({
+                    ...doc.toObject().stix,
+                    ...doc.toObject().metaProperties
+                }));
+            const indicatorRisks = [];
+
+            const sensors = results[2]
+                .filter(doc => doc !== undefined)
+                .map(doc => ({
+                    ...doc.toObject().stix,
+                    ...doc.toObject().metaProperties
+                }));
+            const sensorRisks = [];
+
             const returnObject = {};
             returnObject.indicators = [];
             returnObject.sensors = [];


### PR DESCRIPTION
fixes unfetter-discover/unfetter#1095
we can merge into develop, then repush the 0.3.7 branch, since no other changes were made

## problem
v2 assessments summary shows empty panel

## changes
update ordering of results array to result types

## test
pull this PR
visit the v2 assessments summary panel for 'indicators', 'mitigations', and 'sensors' ensure the top right panel is populated