### PR TITLE
Makes authentication services dynamic loading

### DIFF
--- a/unfetter-discover-api/api/helpers/auth_helpers.js
+++ b/unfetter-discover-api/api/helpers/auth_helpers.js
@@ -135,10 +135,43 @@ const storeRegistration = (user, res) => {
     );
 };
 
+const AuthHelper = class {
+
+    constructor(name) {
+        this.name = name;
+    }
+
+    build(config, env) {
+        return null;
+    }
+
+    options() {
+        return null;
+    }
+
+    search(user) {
+        return null;
+    }
+
+    sync(user, loginInfo, approved) {
+        user.oauth = this.name;
+        user.approved = approved;
+        if (!user[this.name]) {
+            user[this.name] = {
+                id: loginInfo.id,
+                userName: null,
+                avatar: null,
+            };
+        }
+    }
+
+};
+
 module.exports = {
     setEmptyResponse,
     setErrorResponse,
     handleLoginCallback,
     startRegistration,
     storeRegistration,
+    AuthHelper,
 };

--- a/unfetter-discover-api/api/helpers/github-auth.js
+++ b/unfetter-discover-api/api/helpers/github-auth.js
@@ -1,8 +1,13 @@
 const GithubStrategy = require('passport-github').Strategy;
+const AuthHelper = require('../helpers/auth_helpers').AuthHelper;
 
-(() => ({
+class GithubAuth extends AuthHelper {
 
-    build: (config, env) => {
+    constructor() {
+        super('github');
+    }
+
+    build(config, env) {
         const githubStrategy = new GithubStrategy(
             {
                 ...config.github,
@@ -18,28 +23,24 @@ const GithubStrategy = require('passport-github').Strategy;
             console.log('Not using a proxy');
         }
         return githubStrategy;
-    },
+    }
 
-    options: () => ({ scope: ['user:email'] }),
+    options() {
+        return { scope: ['user:email'] };
+    }
 
-    search: user => ({
-        'github.id': user.id
-    }),
+    search(user) {
+        return { 'github.id': user.id };
+    }
 
-    sync: (storedUser, userinfo, approved) => {
-        storedUser.oauth = 'github';
-        if (!storedUser.github) {
-            storedUser.github = {
-                id: userinfo.id,
-                userName: null,
-                avatar: null,
-            };
+    sync(user, githubInfo, approved) {
+        super.sync(user, githubInfo, approved);
+        user.github.userName = githubInfo.username;
+        if (githubInfo._json.avatar_url) {
+            user.github.avatar_url = githubInfo._json.avatar_url;
         }
-        storedUser.approved = approved;
-        storedUser.github.userName = userinfo.username;
-        if (userinfo._json.avatar_url) {
-            storedUser.github.avatar_url = userinfo._json.avatar_url;
-        }
-    },
+    }
 
-}))();
+}
+
+(() => new GithubAuth())();

--- a/unfetter-discover-api/api/helpers/github-auth.js
+++ b/unfetter-discover-api/api/helpers/github-auth.js
@@ -1,6 +1,6 @@
 const GithubStrategy = require('passport-github').Strategy;
 
-module.exports = {
+(() => ({
 
     build: (config, env) => {
         const githubStrategy = new GithubStrategy(
@@ -20,9 +20,11 @@ module.exports = {
         return githubStrategy;
     },
 
-    options: { scope: ['user:email'] },
+    options: () => ({ scope: ['user:email'] }),
 
-    search: user => ({ 'github.id': user.id }),
+    search: user => ({
+        'github.id': user.id
+    }),
 
     sync: (storedUser, userinfo, approved) => {
         storedUser.oauth = 'github';
@@ -40,4 +42,4 @@ module.exports = {
         }
     },
 
-};
+}))();

--- a/unfetter-discover-api/api/helpers/gitlab-auth.js
+++ b/unfetter-discover-api/api/helpers/gitlab-auth.js
@@ -1,8 +1,13 @@
 const GitlabStrategy = require('passport-gitlab').Strategy;
+const AuthHelper = require('../helpers/auth_helpers').AuthHelper;
 
-(() => ({
+class GitlabAuth extends AuthHelper {
 
-    build: (config, env) => {
+    constructor() {
+        super('gitlab');
+    }
+
+    build(config, env) {
         const gitlabStrategy = new GitlabStrategy(
             {
                 ...config.gitlab,
@@ -18,26 +23,20 @@ const GitlabStrategy = require('passport-gitlab').Strategy;
             console.log('Not using a proxy');
         }
         return gitlabStrategy;
-    },
+    }
 
-    options: () => null,
+    search(user) {
+        return { 'gitlab.id': user.id };
+    }
 
-    search: user => ({ 'gitlab.id': user.id }),
-
-    sync: (user, gitlabInfo, approved) => {
-        user.oauth = 'gitlab';
-        user.approved = approved;
-        if (!user.gitlab) {
-            user.gitlab = {
-                id: gitlabInfo.id,
-                userName: null,
-                avatar: null,
-            };
-        }
+    sync(user, gitlabInfo, approved) {
+        super.sync(user, gitlabInfo, approved);
         user.gitlab.userName = gitlabInfo.username;
         if (gitlabInfo._json.avatar_url) {
             user.gitlab.avatar_url = gitlabInfo._json.avatar_url;
         }
-    },
+    }
 
-}))();
+}
+
+(() => new GitlabAuth())();

--- a/unfetter-discover-api/api/helpers/gitlab-auth.js
+++ b/unfetter-discover-api/api/helpers/gitlab-auth.js
@@ -1,6 +1,6 @@
 const GitlabStrategy = require('passport-gitlab').Strategy;
 
-module.exports = {
+(() => ({
 
     build: (config, env) => {
         const gitlabStrategy = new GitlabStrategy(
@@ -20,7 +20,7 @@ module.exports = {
         return gitlabStrategy;
     },
 
-    options: {},
+    options: () => null,
 
     search: user => ({ 'gitlab.id': user.id }),
 
@@ -40,4 +40,4 @@ module.exports = {
         }
     },
 
-};
+}))();

--- a/unfetter-discover-api/api/helpers/ldap-auth.js
+++ b/unfetter-discover-api/api/helpers/ldap-auth.js
@@ -1,0 +1,36 @@
+// const LDAPStrategy = require('passport-ldap').Strategy;
+
+(() => ({
+
+    build: (config, env) => {
+        // const ldapStrategy = new LDAPStrategy(
+        //     {
+        //         ...config.ldap,
+        //         callbackURL: `${(env.API_ROOT || 'https://localhost/api')}/auth/ldap-callback`
+        //     },
+        //     (accessToken, refreshToken, profile, callback) => callback(null, profile)
+        // );
+        // return ldapStrategy;
+    },
+
+    options: () => null,
+
+    search: user => ({ 'ldap.id': user.id }),
+
+    sync: (storedUser, userinfo, approved) => {
+        // storedUser.oauth = 'ldap';
+        // if (!storedUser.github) {
+        //     storedUser.github = {
+        //         id: userinfo.id,
+        //         userName: null,
+        //         avatar: null,
+        //     };
+        // }
+        // storedUser.approved = approved;
+        // storedUser.github.userName = userinfo.username;
+        // if (userinfo._json.avatar_url) {
+        //     storedUser.github.avatar_url = userinfo._json.avatar_url;
+        // }
+    },
+
+}))();

--- a/unfetter-discover-api/api/helpers/ldap-auth.js
+++ b/unfetter-discover-api/api/helpers/ldap-auth.js
@@ -1,36 +1,11 @@
-// const LDAPStrategy = require('passport-ldap').Strategy;
+const AuthHelper = require('../helpers/auth_helpers').AuthHelper;
 
-(() => ({
+class LdapAuth extends AuthHelper {
 
-    build: (config, env) => {
-        // const ldapStrategy = new LDAPStrategy(
-        //     {
-        //         ...config.ldap,
-        //         callbackURL: `${(env.API_ROOT || 'https://localhost/api')}/auth/ldap-callback`
-        //     },
-        //     (accessToken, refreshToken, profile, callback) => callback(null, profile)
-        // );
-        // return ldapStrategy;
-    },
+    search(user) {
+        return { 'ldap.id': user.id };
+    }
 
-    options: () => null,
+}
 
-    search: user => ({ 'ldap.id': user.id }),
-
-    sync: (storedUser, userinfo, approved) => {
-        // storedUser.oauth = 'ldap';
-        // if (!storedUser.github) {
-        //     storedUser.github = {
-        //         id: userinfo.id,
-        //         userName: null,
-        //         avatar: null,
-        //     };
-        // }
-        // storedUser.approved = approved;
-        // storedUser.github.userName = userinfo.username;
-        // if (userinfo._json.avatar_url) {
-        //     storedUser.github.avatar_url = userinfo._json.avatar_url;
-        // }
-    },
-
-}))();
+(() => new LdapAuth())();

--- a/unfetter-discover-api/api/helpers/mongo-auth.js
+++ b/unfetter-discover-api/api/helpers/mongo-auth.js
@@ -7,47 +7,47 @@
 /**
  * @todo This strategy is not fully implemented.
  */
-module.exports = {
+(() => ({
 
-    // build: (config, env) => {
-    //     const mongoStrategy = new LocalStrategy((username, password, callback) => {
-    //         UserAuth.findOne({ userName: username }, (err, user) => {
-    //             if (err) {
-    //                 console.log('mongo error', err);
-    //                 return callback(err);
-    //             }
-    //             if (!user) {
-    //                 console.log('no such user');
-    //                 return callback(null, false, { message: 'Invalid username.' });
-    //             }
-    //             if (!scrypt.verifyHashSync(user.hash, password)) {
-    //                 console.log('password hash failed', user.hash);
-    //                 return callback(null, false, { message: 'Incorrect password.' });
-    //             }
-    //             return callback(null, user);
-    //         });
-    //     });
-    //     return mongoStrategy;
-    // },
+    build: (config, env) => {
+        // const mongoStrategy = new LocalStrategy((username, password, callback) => {
+        //     UserAuth.findOne({ userName: username }, (err, user) => {
+        //         if (err) {
+        //             console.log('mongo error', err);
+        //             return callback(err);
+        //         }
+        //         if (!user) {
+        //             console.log('no such user');
+        //             return callback(null, false, { message: 'Invalid username.' });
+        //         }
+        //         if (!scrypt.verifyHashSync(user.hash, password)) {
+        //             console.log('password hash failed', user.hash);
+        //             return callback(null, false, { message: 'Incorrect password.' });
+        //         }
+        //         return callback(null, user);
+        //     });
+        // });
+        // return mongoStrategy;
+    },
 
-    // options: { scope: ['user:email'] },
+    options: () => null,
 
-    // search: user => ({ 'mongo.id': user.id }),
+    search: user => ({ 'mongo.id': user.id }),
 
-    // sync: (storedUser, userinfo, approved) => {
-    //     storedUser.oauth = 'mongo';
-    //     if (!storedUser.github) {
-    //         storedUser.github = {
-    //             id: userinfo.id,
-    //             userName: null,
-    //             avatar: null,
-    //         };
-    //     }
-    //     storedUser.approved = approved;
-    //     storedUser.github.userName = userinfo.username;
-    //     if (userinfo._json.avatar_url) {
-    //         storedUser.github.avatar_url = userinfo._json.avatar_url;
-    //     }
-    // },
+    sync: (storedUser, userinfo, approved) => {
+        // storedUser.oauth = 'mongo';
+        // if (!storedUser.github) {
+        //     storedUser.github = {
+        //         id: userinfo.id,
+        //         userName: null,
+        //         avatar: null,
+        //     };
+        // }
+        // storedUser.approved = approved;
+        // storedUser.github.userName = userinfo.username;
+        // if (userinfo._json.avatar_url) {
+        //     storedUser.github.avatar_url = userinfo._json.avatar_url;
+        // }
+    },
 
-};
+}))();

--- a/unfetter-discover-api/api/helpers/mongo-auth.js
+++ b/unfetter-discover-api/api/helpers/mongo-auth.js
@@ -3,51 +3,14 @@
 // const LocalStrategy = require('passport-local').Strategy;
 // const scrypt = require('scrypt');
 // const scryptParameters = scrypt.paramsSync(0.1, 1);
+const AuthHelper = require('../helpers/auth_helpers').AuthHelper;
 
-/**
- * @todo This strategy is not fully implemented.
- */
-(() => ({
+class MongoAuth extends AuthHelper {
 
-    build: (config, env) => {
-        // const mongoStrategy = new LocalStrategy((username, password, callback) => {
-        //     UserAuth.findOne({ userName: username }, (err, user) => {
-        //         if (err) {
-        //             console.log('mongo error', err);
-        //             return callback(err);
-        //         }
-        //         if (!user) {
-        //             console.log('no such user');
-        //             return callback(null, false, { message: 'Invalid username.' });
-        //         }
-        //         if (!scrypt.verifyHashSync(user.hash, password)) {
-        //             console.log('password hash failed', user.hash);
-        //             return callback(null, false, { message: 'Incorrect password.' });
-        //         }
-        //         return callback(null, user);
-        //     });
-        // });
-        // return mongoStrategy;
-    },
+    search(user) {
+        return { 'mongo.id': user.id };
+    }
 
-    options: () => null,
+}
 
-    search: user => ({ 'mongo.id': user.id }),
-
-    sync: (storedUser, userinfo, approved) => {
-        // storedUser.oauth = 'mongo';
-        // if (!storedUser.github) {
-        //     storedUser.github = {
-        //         id: userinfo.id,
-        //         userName: null,
-        //         avatar: null,
-        //     };
-        // }
-        // storedUser.approved = approved;
-        // storedUser.github.userName = userinfo.username;
-        // if (userinfo._json.avatar_url) {
-        //     storedUser.github.avatar_url = userinfo._json.avatar_url;
-        // }
-    },
-
-}))();
+(() => new MongoAuth())();


### PR DESCRIPTION
Fixes unfetter-discover/unfetter#1104.

- Should require no changes to any configurations
- unfetter-discover-api should still come up, and you should be able to find a line early in the log saying `passport strategies loaded:  [ 'github' ]` or similar (array should not be empty, at least).
- You should still be able to log in to the UI without issues.