### PR TITLE
improve error handling on fetch

### DIFF
--- a/unfetter-discover-processor/src/app.ts
+++ b/unfetter-discover-processor/src/app.ts
@@ -131,9 +131,13 @@ async function init() {
 
         // ~~~ MITRE ATT&CK Data ~~~
         if (argv.mitreAttackData !== undefined && argv.mitreAttackData.length) {
-            console.log('Adding the following Mitre ATT&CK data:', argv.mitreAttackData);
-            const mitreData = await getMitreData(argv.mitreAttackData);
-            stixObjects = stixObjects.concat(mitreData);
+            try {                
+                console.log('Adding the following Mitre ATT&CK data:', argv.mitreAttackData);
+                const mitreData = await getMitreData(argv.mitreAttackData);
+                stixObjects = stixObjects.concat(mitreData);
+            } catch (mitreError) {
+                console.log('Error while attempting to fetch MITRE data: ', mitreError);
+            }
         }
 
         // ~~~ TAXII Server Data ~~~


### PR DESCRIPTION
Instructions:

Confirm processor works as expected:
- Delete STIX collection contents `db.getCollection('stix').remove({})`
- Restart stack
- Confirm all data was loaded `db.getCollection('stix').find({}).count()` (should be ~4497)
- Confirm pattern translations occured `db.getCollection('stix').find({ 'metaProperties.validStixPattern': { $exists: 1} }).count()`(should be ~45)

Confirm processor works without access to pattern handler:
- In the entry point to unfetter-discover-processor, add the following lines to make the pattern handle unreachable:

```
     - --pattern-handler-domain
     - fake
```

- Delete STIX collection contents `db.getCollection('stix').remove({})`
- Restart stack
- Confirm all data was loaded `db.getCollection('stix').find({}).count()` (should be ~4497)
- Confirm pattern translations didn't occur `db.getCollection('stix').find({ 'metaProperties.validStixPattern': { $exists: 1} }).count()`(should be 0)

fixes unfetter-discover/unfetter#1128