### PR TITLE
Configurable IPGeo service

### DIFF
--- a/unfetter-discover-api/api/config/ipgeo-config.js
+++ b/unfetter-discover-api/api/config/ipgeo-config.js
@@ -6,18 +6,16 @@ const IPGeoProvider = require('../models/ipgeo').IPGeoProvider;
  */
 const IPGEO_PROVIDERS = [
     // another free service allows up to 1500 requests per day, can be bulk(?)
-    new IPGeoProvider('ipdata.co', 'https://api.ipdata.co/*'),
+    new IPGeoProvider('ipdata.co', 'https://api.ipdata.co/*')
+        .withTranslate(json => ({ ...json, country: json.country_code })),
 
     // free-version service allows up to 1000 requests per day, no bulk queries
     new IPGeoProvider('ipapi.co', 'https://ipapi.co/*/json/'),
 
-    // free-version service allows up to 10,000 requests per MONTH (bah!), can be bulk,
-    // and being replaced by newer (still free) service that requires sign-up by 1 July 2018
-    new IPGeoProvider('freegeoip', 'https://freegeoip.net/json/*', false),
-
     // new endpoint for freegeoip with personal key ()
     new IPGeoProvider('ipstack.com', 'http://api.ipstack.com/*', true, ',')
-        .withQueryParamKey('access_key', '64a9512c200c1edd5b5b521a441f0eff'),
+        .withQueryParamKey('access_key', '64a9512c200c1edd5b5b521a441f0eff')
+        .withTranslate(json => ({ ...json, country: json.country_code })),
 ];
 
 module.exports = {

--- a/unfetter-discover-api/api/config/ipgeo-config.js
+++ b/unfetter-discover-api/api/config/ipgeo-config.js
@@ -1,0 +1,25 @@
+const IPGeoProvider = require('../models/ipgeo').IPGeoProvider;
+
+/*
+ * To override this in a deployment, you will need to copy this file and replace the providers below. This is due to
+ * the nature that the providers can provide behavior (functions), and that cannot be overridden in a JSON file.
+ */
+const IPGEO_PROVIDERS = [
+    // another free service allows up to 1500 requests per day, can be bulk(?)
+    new IPGeoProvider('ipdata.co', 'https://api.ipdata.co/*'),
+
+    // free-version service allows up to 1000 requests per day, no bulk queries
+    new IPGeoProvider('ipapi.co', 'https://ipapi.co/*/json/'),
+
+    // free-version service allows up to 10,000 requests per MONTH (bah!), can be bulk,
+    // and being replaced by newer (still free) service that requires sign-up by 1 July 2018
+    new IPGeoProvider('freegeoip', 'https://freegeoip.net/json/*', false),
+
+    // new endpoint for freegeoip with personal key ()
+    new IPGeoProvider('ipstack.com', 'http://api.ipstack.com/*', true, ',')
+        .withQueryParamKey('access_key', '64a9512c200c1edd5b5b521a441f0eff'),
+];
+
+module.exports = {
+    IPGEO_PROVIDERS,
+};

--- a/unfetter-discover-api/api/controllers/ipgeo.js
+++ b/unfetter-discover-api/api/controllers/ipgeo.js
@@ -85,7 +85,9 @@ function queryProviders(providers, ip, res, error = RequestError.create()) {
         timeout
     }).then(response => response
         .json())
-        .then(json => res.status(200).json({ data: { success: true, provider: provider.id, ...json } }))
+        .then(json => res.status(200).json({
+            data: { success: true, provider: provider.id, ...provider.translate(json) }
+        }))
         .catch(ex => {
             error.addError().source(provider.id).message(ex);
             queryProviders(providers, ip, res, error);

--- a/unfetter-discover-api/api/controllers/ipgeo.js
+++ b/unfetter-discover-api/api/controllers/ipgeo.js
@@ -1,5 +1,6 @@
 const fetch = require('node-fetch');
 const ipregex = require('ip-regex');
+const IPGEO_PROVIDERS = require('../config/ipgeo-config').IPGEO_PROVIDERS;
 
 /**
  * Uses the Builder pattern.
@@ -58,51 +59,6 @@ class RequestError {
     }
 
 }
-
-class IPGeoProvider {
-    constructor(id, url, active = true, batchSeparator = null) {
-        this.id = id;
-        this.url = url;
-        this.active = active;
-        this.batchSeparator = batchSeparator;
-        this.setKey = req => {};
-    }
-
-    withHeaderKey(header, key) {
-        this.setKey = req => {
-            req.headers = { header, key, };
-        };
-        return this;
-    }
-
-    withQueryParamKey(param, key) {
-        this.setKey = req => {
-            req.uri = `${req.uri}${(req.uri.indexOf('?') > 0) ? '&' : '?'}${param}=${key}`;
-        };
-        return this;
-    }
-}
-
-/*
- * TODO Need to find a way to add this information to the system configuration (not something a user needs to see).
- *      If we do so, we can also do more to add the optional/required personal keys that some providers require, or
- *      that can be purchased.
- */
-const IPGEO_PROVIDERS = [
-    // another free service allows up to 1500 requests per day, can be bulk(?)
-    new IPGeoProvider('ipdata.co', 'https://api.ipdata.co/*'),
-
-    // free-version service allows up to 1000 requests per day, no bulk queries
-    new IPGeoProvider('ipapi.co', 'https://ipapi.co/*/json/'),
-
-    // free-version service allows up to 10,000 requests per MONTH (bah!), can be bulk,
-    // and being replaced by newer (still free) service that requires sign-up by 1 July 2018
-    new IPGeoProvider('freegeoip', 'https://freegeoip.net/json/*', false),
-
-    // new endpoint for freegeoip with personal key ()
-    new IPGeoProvider('ipstack.com', 'http://api.ipstack.com/*', true, ',')
-        .withQueryParamKey('access_key', '64a9512c200c1edd5b5b521a441f0eff'),
-];
 
 /**
  * @param {IPGeoProvider} provider

--- a/unfetter-discover-api/api/models/ipgeo.js
+++ b/unfetter-discover-api/api/models/ipgeo.js
@@ -6,6 +6,7 @@ class IPGeoProvider {
         this.active = active;
         this.batchSeparator = batchSeparator;
         this.setKey = req => {};
+        this.translate = json => json;
     }
 
     withHeaderKey(header, key) {
@@ -19,6 +20,11 @@ class IPGeoProvider {
         this.setKey = req => {
             req.uri = `${req.uri}${(req.uri.indexOf('?') > 0) ? '&' : '?'}${param}=${key}`;
         };
+        return this;
+    }
+
+    withTranslate(translate) {
+        this.translate = translate;
         return this;
     }
 

--- a/unfetter-discover-api/api/models/ipgeo.js
+++ b/unfetter-discover-api/api/models/ipgeo.js
@@ -1,0 +1,27 @@
+class IPGeoProvider {
+
+    constructor(id, url, active = true, batchSeparator = null) {
+        this.id = id;
+        this.url = url;
+        this.active = active;
+        this.batchSeparator = batchSeparator;
+        this.setKey = req => {};
+    }
+
+    withHeaderKey(header, key) {
+        this.setKey = req => {
+            req.headers = { header, key, };
+        };
+        return this;
+    }
+
+    withQueryParamKey(param, key) {
+        this.setKey = req => {
+            req.uri = `${req.uri}${(req.uri.indexOf('?') > 0) ? '&' : '?'}${param}=${key}`;
+        };
+        return this;
+    }
+
+}
+
+module.exports = { IPGeoProvider };


### PR DESCRIPTION
Support unfetter-discover/unfetter#1164.

With PR https://github.com/unfetter-discover/unfetter-ui/pull/510.

Moves IPGeo service configuration to a file that can be overridden on image deployment to internal systems.

Nothing really to test here unless you create your own docker-compose YAML file, and add a volume override to the discover-api's api/config/ipgeo-config.js file.