### PR TITLE
allow assessed objects to save

### DIFF
--- a/unfetter-discover-api/api/models/x-unfetter-object-assessment.js
+++ b/unfetter-discover-api/api/models/x-unfetter-object-assessment.js
@@ -1,5 +1,6 @@
 const mongoose = require('mongoose');
 const stixCommons = require('./stix-commons');
+const xunfetterAssessObject = require('./x-unfetter-assessed-object').xunfetterAssessObject;
 
 const StixSchema = {
     created_by_ref: {
@@ -21,7 +22,7 @@ const StixSchema = {
         type: String,
         required: [true, 'object_ref is required']
     },
-    assessed_objects: [{ type: mongoose.Schema.Types.ObjectId, ref: 'XUnfetterAssessedObject' }]
+    assessed_objects: [xunfetterAssessObject]
 };
 
 const objectAssessment = mongoose.model('XUnfetterObjectAssessment', stixCommons.makeSchema(StixSchema), 'stix');

--- a/unfetter-discover-api/api/swagger/definitions/x_unfetter_object_assessments/x_unfetter_object_assessment.yaml
+++ b/unfetter-discover-api/api/swagger/definitions/x_unfetter_object_assessments/x_unfetter_object_assessment.yaml
@@ -13,7 +13,7 @@
       modified:
         type: string
         format: date-time
-      assessment_objects:
+      assessed_objects:
         type: array
         items:
           properties:

--- a/unfetter-discover-api/api/swagger/definitions/x_unfetter_object_assessments/x_unfetter_object_assessment_create_update.yaml
+++ b/unfetter-discover-api/api/swagger/definitions/x_unfetter_object_assessments/x_unfetter_object_assessment_create_update.yaml
@@ -19,7 +19,7 @@ properties:
           modified:
             type: string
             format: date-time
-          assessment_objects:
+          assessed_objects:
             type: array
             items:
               properties:


### PR DESCRIPTION
Fixes unfetter-discover/unfetter#1171

Model for x-unfetter-object-assessment doesn't allow its assessed_objects to be saved - reference for that part of the model has been corrected.

##To test:
1. Pull this branch
2. Restart stack
3. Access API page, and navigate to x-unfetter-object-assessment
4. For POST, click `try it out` and enter this for the `data` value:
```
{
    "data": {
        "attributes": {
            "created": "2018-06-14T18:50:16.132Z",
            "valid_from": "2018-06-14T18:50:16.132Z",
            "version": 2,
            "type": "x-unfetter-object-assessment",
            "object_ref": "x-unfetter-capability--2288d472-daeb-4be5-82f2-03b3d8eb3c51",
            "assessed_objects": [
                {
                    "assessed_object_ref": "attack-pattern--8b6c02f6-5c43-4742-97d7-8bacd2a87cb2",
                    "id": "x-unfetter-assessed-object--d871eb2b-0c9b-41dd-ba51-7c22a3452752",
                    "questions": [
                        {
                            "score": "M",
                            "name": "protect"
                        },
                        {
                            "score": "S",
                            "name": "detect"
                        },
                        {
                            "score": "L",
                            "name": "respond"
                        }
                    ],
                    "type": "x-unfetter-assessed-object"
                },
                {
                    "assessed_object_ref": "attack-pattern--2a487f65-3cf8-4c07-ace3-21577e08c832",
                    "id": "x-unfetter-assessed-object--e19f08db-f71a-4aee-b795-b774261de315",
                    "questions": [
                        {
                            "score": "M",
                            "name": "protect"
                        },
                        {
                            "score": "S",
                            "name": "detect"
                        },
                        {
                            "score": "L",
                            "name": "respond"
                        }
                    ],
                    "type": "x-unfetter-assessed-object"
                },
                {
                    "assessed_object_ref": "attack-pattern--56a26dfe-762b-4c66-9b0d-94e327fcd307",
                    "id": "x-unfetter-assessed-object--e19f08db-f71a-4aee-b795-b774261de315",
                    "questions": [
                        {
                            "score": "L",
                            "name": "protect"
                        },
                        {
                            "score": "L",
                            "name": "detect"
                        },
                        {
                            "score": "L",
                            "name": "respond"
                        }
                    ],
                    "type": "x-unfetter-assessed-object"
                }
            ],
            "description": "Ipfirewall or ipfw is a FreeBSD IP packet filter and traffic accounting facility.",
            "name": "Ipfirewall",
            "created_by_ref": "identity--e240b257-5c42-402e-a0e8-7b81ecc1c09a"
        }
    }
}
```
5. Click `Execute` and verify a 201 return value and make sure the returned x-unfetter-object-assessment is complete and includes the assessed_objects array passed in
