### PR TITLE
show assessed phases for all assessment types, 

### DIFF
--- a/unfetter-discover-api/api/controllers/x_unfetter_assessments.js
+++ b/unfetter-discover-api/api/controllers/x_unfetter_assessments.js
@@ -1,5 +1,6 @@
 const AssessmentPipelineHelper = require('../helpers/assessment_pipeline_helper');
 const BaseController = require('./shared/basecontroller');
+
 const controller = new BaseController('x-unfetter-assessment');
 const jsonApiConverter = require('../helpers/json_api_converter');
 const lodash = require('lodash');
@@ -315,8 +316,8 @@ const risk = controller.getByIdCb((err, result, req, res, id) => { // eslint-dis
  * An Attack Pattern has a kill chain.  Indicators, Sensors and COA have also been given
  * kill chains to allow them to be grouped.  This function will return all the assessment
  * for ATTACK Kill Chains
- * @param {*} req 
- * @param {*} res 
+ * @param {*} req
+ * @param {*} res
  */
 const riskByAttackPatternAndKillChain = (req, res) => {
     const id = req.swagger.params.id ? req.swagger.params.id.value : '';
@@ -373,9 +374,9 @@ const riskByAttackPatternAndKillChain = (req, res) => {
 };
 
 /**
- * 
- * @param {*} req 
- * @param {*} res 
+ *
+ * @param {*} req
+ * @param {*} res
  */
 const summaryAggregations = (req, res) => {
     const id = req.swagger.params.id ? req.swagger.params.id.value : '';
@@ -568,8 +569,6 @@ const getAnswerByAssessedObject = controller.getByIdCb((err, result, req, res, i
     });
 });
 
-
-
 /**
  * @description With a given assessmentID, and assessedObjectId, and a new answer value, go through the questions
  * of that assessed object and give the new answers.
@@ -650,35 +649,35 @@ const updateAnswerByAssessedObject = controller.getByIdCb((err, result, req, res
             Model.findOneAndUpdate({
                 _id: id
             }, newDocument, {
-                    new: true
-                }, (errUpdate, resultUpdate) => {
-                    if (errUpdate) {
-                        return res.status(500).json({
-                            errors: [{
-                                status: 500,
-                                source: '',
-                                title: 'Error',
-                                code: '',
-                                detail: 'An unknown error has occurred.'
-                            }]
-                        });
-                    }
-
-                    if (resultUpdate) {
-                        const requestedUrl = apiRoot + req.originalUrl;
-                        const convertedResult = jsonApiConverter.convertJsonToJsonApi(resultUpdate.stix, assessment.stix.type, requestedUrl);
-                        return res.status(200).json({
-                            links: {
-                                self: requestedUrl,
-                            },
-                            data: convertedResult
-                        });
-                    }
-
-                    return res.status(404).json({
-                        message: `Unable to update the item.  No item found with id ${id}`
+                new: true
+            }, (errUpdate, resultUpdate) => {
+                if (errUpdate) {
+                    return res.status(500).json({
+                        errors: [{
+                            status: 500,
+                            source: '',
+                            title: 'Error',
+                            code: '',
+                            detail: 'An unknown error has occurred.'
+                        }]
                     });
+                }
+
+                if (resultUpdate) {
+                    const requestedUrl = apiRoot + req.originalUrl;
+                    const convertedResult = jsonApiConverter.convertJsonToJsonApi(resultUpdate.stix, assessment.stix.type, requestedUrl);
+                    return res.status(200).json({
+                        links: {
+                            self: requestedUrl,
+                        },
+                        data: convertedResult
+                    });
+                }
+
+                return res.status(404).json({
+                    message: `Unable to update the item.  No item found with id ${id}`
                 });
+            });
         } catch (error) {
             console.log(`error ${error}`);
             return res.status(500).json({
@@ -742,19 +741,19 @@ const latestAssessmentPromise = (query, req, res) => {
                     // TODO remove this when a better fix is in place
                     if (r.stix.type) {
                         switch (r.stix.type) {
-                            case 'course-of-action':
-                                retVal.name = `${r.name} - Mitigations`;
-                                break;
-                            case 'indicator':
-                                retVal.name = `${r.name} - Indicators`;
-                                break;
-                            case 'x-unfetter-sensor':
-                                retVal.name = `${r.name} - Sensors`;
-                                break;
-                            case 'x-unfetter-object-assessment':
-                                retVal.name = `${r.name} - Capabilities`;
-                                break;
-                            default:
+                        case 'course-of-action':
+                            retVal.name = `${r.name} - Mitigations`;
+                            break;
+                        case 'indicator':
+                            retVal.name = `${r.name} - Indicators`;
+                            break;
+                        case 'x-unfetter-sensor':
+                            retVal.name = `${r.name} - Sensors`;
+                            break;
+                        case 'x-unfetter-object-assessment':
+                            retVal.name = `${r.name} - Capabilities`;
+                            break;
+                        default:
                         }
                     }
                     return retVal;

--- a/unfetter-discover-api/api/helpers/assessment_pipeline_helper.js
+++ b/unfetter-discover-api/api/helpers/assessment_pipeline_helper.js
@@ -40,7 +40,7 @@ const buildAttackPatternByKillChainPipeline = (id = '', isCapability = false) =>
     ];
 
     return pipeline;
-}
+};
 
 /**
  * @description - builds the pipeline for an assessments attack pattern
@@ -92,7 +92,7 @@ const buildAttackPatternAggregationsPipeline = (id = '', isCapability = false) =
     ];
 
     return pipeline;
-}
+};
 
 /**
  * @description - the initial matcher pipeline phase for an assessments query
@@ -110,7 +110,7 @@ const buildAssessmentInitialMatcherPipeline = (id = '') => {
         },
     ];
     return initialMatcher;
-}
+};
 
 /**
  * @description - the pipeline phase to take a capability and generated its related attack patterns
@@ -119,24 +119,24 @@ const buildAssessmentInitialMatcherPipeline = (id = '') => {
 const buildAssessmentCapabilityToAttackPatternPipeline = () => {
     const capabilityAssessmentToAttackPatterns = [
         {
-            '$lookup': {
+            $lookup: {
                 from: 'stix', localField: 'stix.assessment_objects.stix.id', foreignField: 'stix.id', as: 'object_assessments'
             }
         },
         {
-            '$unwind': '$object_assessments'
+            $unwind: '$object_assessments'
         },
         {
-            $replaceRoot: { newRoot: "$object_assessments" }
+            $replaceRoot: { newRoot: '$object_assessments' }
         },
         {
-            '$unwind': '$stix.assessment_objects'
+            $unwind: '$stix.assessment_objects'
         },
         {
-            $replaceRoot: { newRoot: "$stix.assessment_objects" }
+            $replaceRoot: { newRoot: '$stix.assessment_objects' }
         },
         {
-            $project: { 'attackPatterns': '$assessed_object_ref' }
+            $project: { attackPatterns: '$assessed_object_ref' }
         },
         {
             $group: {
@@ -154,7 +154,7 @@ const buildAssessmentCapabilityToAttackPatternPipeline = () => {
     ];
 
     return capabilityAssessmentToAttackPatterns;
-}
+};
 
 /**
  * @description - the pipeline phase to take an assessments relationship objects and generated its retrieve attack patterns
@@ -191,7 +191,7 @@ const buildAssessmentRelationsToAttackPatternPipeline = () => {
     ];
 
     return assessmentRelationshipsToAttackPatterns;
-}
+};
 
 /**
  * @description - the pipeline to query for attack patterns by kill chain
@@ -241,7 +241,7 @@ const buildAttackPatternsByKillChainPipeline = () => {
     ];
 
     return pipeline;
-}
+};
 
 module.exports = {
     buildAssessmentCapabilityToAttackPatternPipeline,
@@ -251,7 +251,3 @@ module.exports = {
     buildAttackPatternByKillChainPipeline,
     buildAttackPatternsByKillChainPipeline,
 };
-
-
-
-

--- a/unfetter-discover-api/api/helpers/assessment_pipeline_helper.js
+++ b/unfetter-discover-api/api/helpers/assessment_pipeline_helper.js
@@ -1,0 +1,257 @@
+/**
+ * @description - builds the pipeline for an assessments attack pattern risk by kill chain
+ * @return Array
+ */
+const buildAttackPatternByKillChainPipeline = (id = '', isCapability = false) => {
+    const initialMatcher = buildAssessmentInitialMatcherPipeline(id);
+    // capability vs old relationships assessment style datamodel
+    const assessmentToAttackPatterns = isCapability === true ?
+        buildAssessmentCapabilityToAttackPatternPipeline() : buildAssessmentRelationsToAttackPatternPipeline();
+
+    const pipeline = [
+        ...initialMatcher,
+        ...assessmentToAttackPatterns,
+        {
+            $unwind: '$attackPatterns'
+        },
+        {
+            $match: {
+                'attackPatterns.stix.type': 'attack-pattern'
+            }
+        },
+        {
+            $unwind: '$stix.assessment_objects.questions'
+        },
+        {
+            $group: {
+                _id: '$attackPatterns._id',
+                assessedObjects: {
+                    $addToSet: {
+                        assId: '$stix.assessment_objects.stix.id',
+                        questions: '$stix.assessment_objects.questions',
+                        risk: '$stix.assessment_objects.risk',
+                    }
+                },
+                risk: {
+                    $avg: '$stix.assessment_objects.questions.risk'
+                },
+            }
+        },
+    ];
+
+    return pipeline;
+}
+
+/**
+ * @description - builds the pipeline for an assessments attack pattern
+ * @return Array
+ */
+const buildAttackPatternAggregationsPipeline = (id = '', isCapability = false) => {
+    const initialMatcher = buildAssessmentInitialMatcherPipeline(id);
+    // capability vs old relationships assessment style datamodel
+    const assessmentToAttackPatterns = isCapability === true ?
+        buildAssessmentCapabilityToAttackPatternPipeline() : buildAssessmentRelationsToAttackPatternPipeline();
+
+    const pipeline = [
+        ...initialMatcher,
+        ...assessmentToAttackPatterns,
+        {
+            $unwind: '$attackPatterns'
+        },
+        {
+            $match: {
+                'attackPatterns.stix.type': 'attack-pattern'
+            }
+        },
+        {
+            $unwind: '$attackPatterns.stix.kill_chain_phases'
+        },
+        {
+            $group: {
+                _id: '$attackPatterns.stix.kill_chain_phases.phase_name',
+                attackPatterns: {
+                    $addToSet: {
+                        attackPatternName: '$attackPatterns.stix.name',
+                        attackPatternId: '$attackPatterns._id',
+                    }
+                },
+                assessedObjects: {
+                    $addToSet: {
+                        stix: '$stix.assessment_objects.stix',
+                        questions: '$stix.assessment_objects.questions',
+                        risk: '$stix.assessment_objects.risk',
+                    }
+                },
+            }
+        },
+        {
+            $sort: {
+                _id: 1
+            }
+        },
+    ];
+
+    return pipeline;
+}
+
+/**
+ * @description - the initial matcher pipeline phase for an assessments query
+ * @return Array
+ */
+const buildAssessmentInitialMatcherPipeline = (id = '') => {
+    const initialMatcher = [
+        {
+            $match: {
+                _id: id
+            }
+        },
+        {
+            $unwind: '$stix.assessment_objects'
+        },
+    ];
+    return initialMatcher;
+}
+
+/**
+ * @description - the pipeline phase to take a capability and generated its related attack patterns
+ * @return Array
+ */
+const buildAssessmentCapabilityToAttackPatternPipeline = () => {
+    const capabilityAssessmentToAttackPatterns = [
+        {
+            '$lookup': {
+                from: 'stix', localField: 'stix.assessment_objects.stix.id', foreignField: 'stix.id', as: 'object_assessments'
+            }
+        },
+        {
+            '$unwind': '$object_assessments'
+        },
+        {
+            $replaceRoot: { newRoot: "$object_assessments" }
+        },
+        {
+            '$unwind': '$stix.assessment_objects'
+        },
+        {
+            $replaceRoot: { newRoot: "$stix.assessment_objects" }
+        },
+        {
+            $project: { 'attackPatterns': '$assessed_object_ref' }
+        },
+        {
+            $group: {
+                _id: '$attackPatterns'
+            }
+        },
+        {
+            $lookup: {
+                from: 'stix',
+                localField: '_id',
+                foreignField: 'stix.id',
+                as: 'attackPatterns'
+            }
+        }
+    ];
+
+    return capabilityAssessmentToAttackPatterns;
+}
+
+/**
+ * @description - the pipeline phase to take an assessments relationship objects and generated its retrieve attack patterns
+ * @return Array
+ */
+const buildAssessmentRelationsToAttackPatternPipeline = () => {
+    const assessmentRelationshipsToAttackPatterns = [
+        {
+            $lookup: {
+                from: 'stix',
+                localField: 'stix.assessment_objects.stix.id',
+                foreignField: 'stix.source_ref',
+                as: 'relationships'
+            }
+        },
+        {
+            $unwind: '$relationships'
+        },
+        {
+            $match: {
+                'relationships.stix.target_ref': {
+                    $regex: /^attack-pattern.*/
+                }
+            }
+        },
+        {
+            $lookup: {
+                from: 'stix',
+                localField: 'relationships.stix.target_ref',
+                foreignField: 'stix.id',
+                as: 'attackPatterns'
+            }
+        },
+    ];
+
+    return assessmentRelationshipsToAttackPatterns;
+}
+
+/**
+ * @description - the pipeline to query for attack patterns by kill chain
+ * @return Array
+ */
+const buildAttackPatternsByKillChainPipeline = () => {
+    const pipeline = [
+        {
+            $match: {
+                'stix.type': 'attack-pattern',
+                $nor: [{
+                    'stix.kill_chain_phases': {
+                        $exists: false
+                    }
+                },
+                {
+                    'stix.kill_chain_phases': {
+                        $size: 0
+                    }
+                },
+                ]
+            }
+        },
+        {
+            $addFields: {
+                kill_chain_phases_copy: '$stix.kill_chain_phases',
+            }
+        },
+        {
+            $unwind: '$stix.kill_chain_phases'
+        },
+        {
+            $group: {
+                _id: '$stix.kill_chain_phases.phase_name',
+                attackPatterns: {
+                    $addToSet: {
+                        name: '$stix.name',
+                        x_unfetter_sophistication_level: '$extendedProperties.x_unfetter_sophistication_level',
+                        description: '$stix.description',
+                        kill_chain_phases: '$kill_chain_phases_copy',
+                        external_references: '$stix.external_references',
+                        id: '$stix.id',
+                    },
+                },
+            }
+        },
+    ];
+
+    return pipeline;
+}
+
+module.exports = {
+    buildAssessmentCapabilityToAttackPatternPipeline,
+    buildAssessmentInitialMatcherPipeline,
+    buildAssessmentRelationsToAttackPatternPipeline,
+    buildAttackPatternAggregationsPipeline,
+    buildAttackPatternByKillChainPipeline,
+    buildAttackPatternsByKillChainPipeline,
+};
+
+
+
+

--- a/unfetter-discover-api/api/server/mongoinit.js
+++ b/unfetter-discover-api/api/server/mongoinit.js
@@ -16,7 +16,7 @@ const MAX_GET_PROCESSOR_STATUS_ATTEMPTS = process.env.MAX_GET_PROCESSOR_STATUS_A
 // The amount of time between each connection attempt in ms
 const GET_PROCESSOR_RETRY_TIME = process.env.GET_PROCESSOR_RETRY_TIME || 5000;
 
-const mongoDebug = process.env.MONGO_DEBUG || false;
+const mongoDebug = process.env.MONGO_DEBUG || true;
 mongoose.set('debug', mongoDebug);
 mongoose.Promise = global.Promise;
 

--- a/unfetter-discover-api/api/server/mongoinit.js
+++ b/unfetter-discover-api/api/server/mongoinit.js
@@ -16,7 +16,7 @@ const MAX_GET_PROCESSOR_STATUS_ATTEMPTS = process.env.MAX_GET_PROCESSOR_STATUS_A
 // The amount of time between each connection attempt in ms
 const GET_PROCESSOR_RETRY_TIME = process.env.GET_PROCESSOR_RETRY_TIME || 5000;
 
-const mongoDebug = process.env.MONGO_DEBUG || true;
+const mongoDebug = process.env.MONGO_DEBUG || false;
 mongoose.set('debug', mongoDebug);
 mongoose.Promise = global.Promise;
 

--- a/unfetter-discover-api/api/swagger/paths/x_unfetter_assessments/risk-by-attack-pattern.yaml
+++ b/unfetter-discover-api/api/swagger/paths/x_unfetter_assessments/risk-by-attack-pattern.yaml
@@ -11,6 +11,10 @@ get:
     description: Model ID
     type: string
     required: true
+  - name: isCapability
+    in: query
+    type: boolean
+    description: boolean to query as the capability datamodel
   produces: 
   - application/json
   responses:


### PR DESCRIPTION
supports unfetter-discover/unfetter#1068

Note: unassessed phases need work, and inline edit does work

## problem
assessed phases are in correct in results tab for a beta capability assessment

## changes
* refactored mongo pipeline
* added flag to check assessment type, relations or capability
* apply appropriate mongo pipeline to show risk by attack patterns

## test
create a beta assessment w/ capability scoring
get the capability assessment id
go to swagger
test `GET risk-by-attack-pattern`

_Happy path_
1. try the endpoint with both capability true and false
verify when set to true that the `phases` is populated

_Regression path_
2. test the endpoint with a non capability id
verify the data comes back, the results tab should still work for the other assessment types

See swagger screen shot, with populated phases
![screen shot 2018-06-19 at 1 26 00 pm](https://user-images.githubusercontent.com/30807406/41613881-e884cf64-73c4-11e8-9515-abebe1167d0c.png)

See results tab screen shot, with populated assessed tactics
![screen shot 2018-06-19 at 1 32 53 pm](https://user-images.githubusercontent.com/30807406/41614054-679215a0-73c5-11e8-8d14-7ed28a2cd134.png)

