### PR TITLE
fix risk by attack pattern phases response

### DIFF
--- a/unfetter-discover-api/api/helpers/assessment_pipeline_helper.js
+++ b/unfetter-discover-api/api/helpers/assessment_pipeline_helper.js
@@ -130,10 +130,10 @@ const buildAssessmentCapabilityToAttackPatternPipeline = () => {
             $replaceRoot: { newRoot: '$object_assessments' }
         },
         {
-            $unwind: '$stix.assessment_objects'
+            $unwind: '$stix.assessed_objects'
         },
         {
-            $replaceRoot: { newRoot: '$stix.assessment_objects' }
+            $replaceRoot: { newRoot: '$stix.assessed_objects' }
         },
         {
             $project: { attackPatterns: '$assessed_object_ref' }


### PR DESCRIPTION
## problem
risk by attack pattern mongo aggregation query needed to update in sync w/ previous PR

## changes
change the assessment_objects field to assessed_objects

## test
visit the api page
run `/x-unfetter-assessments/{id}/risk-by-attack-pattern` with a valid capability assessment id, select capability true
verify the phases field is populated
or visit the result tab with a capability beta assessment, verify the tactics column on left is populated

see screen shot in previous PR `issue-1068-beta-assess-results-tab` for a look at a working page