### PR TITLE
user promotion tool can only promote registered users

### DIFF
--- a/unfetter-utils/user_promotion_tool.py
+++ b/unfetter-utils/user_promotion_tool.py
@@ -19,13 +19,6 @@ if __name__ == '__main__':
     users_collection = db[UNFETTER_USERS_COLLECTION]
     users_raw = users_collection.find({ 'registered': True })
     users = [user for user in users_raw]
-
-    print '\n***************\n\nRegistered Users:\n\n\tIndex - User Name - User Role'
-    for i in range(0, len(users)):
-        print '\t' + str(i) + ' -- ' + users[i][u'userName'] + ' -- ' + users[i][u'role']
-
-    print '\n***************\n'
-
     inp = 'y'
     first_go = True
     while inp == 'Y' or inp =='y':
@@ -36,7 +29,6 @@ if __name__ == '__main__':
 
         if inp != 'Y' and inp !='y':
             break
-
         print '\n***************\n\nRegistered Users:\n\n\tIndex - User Name - User Role'
         for i in range(0, len(users)):
             print '\t' + str(i) + ' -- ' + users[i][u'userName'] + ' -- ' + users[i][u'role']

--- a/unfetter-utils/user_promotion_tool.py
+++ b/unfetter-utils/user_promotion_tool.py
@@ -17,9 +17,8 @@ if __name__ == '__main__':
     client = MongoClient(MONGO_HOST, MONGO_PORT)
     db = client[UNFETTER_DATABASE]
     users_collection = db[UNFETTER_USERS_COLLECTION]
-    users_raw = users_collection.find({})
+    users_raw = users_collection.find({ 'registered': True })
     users = [user for user in users_raw]
-    print users[0]
 
     print '\n***************\n\nRegistered Users:\n\n\tIndex - User Name - User Role'
     for i in range(0, len(users)):
@@ -38,6 +37,11 @@ if __name__ == '__main__':
         if inp != 'Y' and inp !='y':
             break
 
+        print '\n***************\n\nRegistered Users:\n\n\tIndex - User Name - User Role'
+        for i in range(0, len(users)):
+            print '\t' + str(i) + ' -- ' + users[i][u'userName'] + ' -- ' + users[i][u'role']
+
+        print '\n***************\n'
         user_index = int(raw_input('Enter the index of the user you wish to edit: '))
 
         print 'Enter the index of the role you wish this user to be:\n\tIndex - User Role'


### PR DESCRIPTION
Instructions:
- Sign in with a new user, and don't complete registration
- Run `user_promotion_tool.py` and confirm the user is *not* on the list
- Complete registration with the user, rerun `user_promotion_tool.py` and confirm the user *is* on the list, promote him to org leader or admin
- Rerun the script again to confirm the correct role is displayed for the user to confirm that the promotion was saved properly