### PR TITLE
Issue 1084

### DIFF
--- a/unfetter-discover-api/api/controllers/x_unfetter_assessments.js
+++ b/unfetter-discover-api/api/controllers/x_unfetter_assessments.js
@@ -65,19 +65,91 @@ function getPromises(assessment) {
             });
     }
 
-    // Generate promises using the ASSESSED_OBJECT_TYPES enum so Promise.all methods get the return in the order expected
+     // Generate promises using the ASSESSED_OBJECT_TYPES enum so Promise.all methods get the return in the order expected
     // Don't bother running a mongo query for empty objects
     const promises = [];
     ASSESSED_OBJECT_QUERY_TYPES.forEach(assessedObjectType => {
         let assessedPromise;
         if (assessedObjectIDs[assessedObjectType] === undefined || assessedObjectIDs[assessedObjectType].length === 0) {
             assessedPromise = Promise.resolve([]);
-        } else {
-            assessedPromise = models[assessedObjectType].find({
-                _id: {
-                    $in: assessedObjectIDs[assessedObjectType]
+        } else if (assessedObjectType !== ASSESSED_OBJECT_QUERY_TYPES[3]) { // capability
+            assessedPromise = models[assessedObjectType].aggregate({
+                $match: {
+                    _id: {
+                        $in: assessedObjectIDs[assessedObjectType]
+                    }
                 }
             });
+        } else {
+            console.log('It\'s a capability!');
+            console.log(`getting ids in assessedObjectIDs[${assessedObjectType}]: ${JSON.stringify(assessedObjectIDs[assessedObjectType])}`);
+            assessedPromise = models[assessedObjectType].aggregate([{
+                $match: {
+                    _id: {
+                        $in: assessedObjectIDs[assessedObjectType]
+                    }
+                }
+            },
+            {
+                $unwind: '$stix.assessed_objects'
+            },
+            {
+                $lookup: {
+                    from: 'stix',
+                    localField: 'stix.assessed_objects.assessed_object_ref',
+                    foreignField: 'stix.id',
+                    as: 'attack_pattern'
+                }
+            },
+            {
+                $unwind: '$attack_pattern'
+            },
+            {
+                $unwind: '$attack_pattern.stix.kill_chain_phases'
+            },
+            {
+                $project: {
+                    _id: 1,
+                    metaProperties: 1,
+                    stix: 1,
+                    kill_chain_phases: '$attack_pattern.stix.kill_chain_phases'
+                }
+            },
+            {
+                $group: {
+                    _id: '$_id',
+                    metaProperties: {
+                        $first: '$metaProperties'
+                    },
+                    stix: {
+                        $first: '$stix',
+                    },
+                    kill_chain_phases: {
+                        $addToSet: {
+                            phase_name: '$kill_chain_phases.phase_name',
+                            kill_chain_name: '$kill_chain_phases.kill_chain_name',
+                        }
+                    }
+                }
+            },
+            {
+                $project: {
+                    _id: 1,
+                    metaProperties: 1,
+                    stix: {
+                        type: 1,
+                        id: 1,
+                        name: 1,
+                        description: 1,
+                        created_by_ref: 1,
+                        created: 1,
+                        modified: 1,
+                        object_ref: 1,
+                        kill_chain_phases: '$kill_chain_phases'
+                    }
+                }
+            }
+            ]);
         }
         promises.push(assessedPromise);
     });
@@ -105,7 +177,7 @@ const assessedObjects = controller.getByIdCb((err, result, req, res, id) => { //
                 .map((returnProp, i) => {
                     const assessmentRisks = results[i]
                         .map(stix => {
-                            const stixObj = stix.toObject();
+                            const stixObj = stix;
                             const assessedData = assessmentObjects.find(assessmentObject => assessmentObject.stix.id === stix._id);
                             if (assessedData !== null && assessedData !== undefined && assessedData.risk !== undefined) {
                                 stixObj.risk = assessedData.risk;
@@ -170,15 +242,15 @@ function groupByKillChain(distinctKillChainPhaseNames, objects, isIndicator) {
 }
 
 // Will group the objects by the kill chain phase name, and will group the risk for each group.
-function calculateRiskPerKillChain(workingObjects, isIndicator) {
+function calculateRiskPerKillChain(workingObjects, useKillChainPhaseName) {
     let collectionName = 'groupings';
     let phaseName = 'groupingValue';
-    if (isIndicator) {
+    if (useKillChainPhaseName) {
         collectionName = 'kill_chain_phases';
         phaseName = 'phase_name';
     }
     const killChains = lodash.sortBy(lodash.uniqBy(lodash.flatMap(lodash.flatMapDeep(workingObjects, collectionName), phaseName)));
-    const groupedObjects = groupByKillChain(killChains, workingObjects, isIndicator);
+    const groupedObjects = groupByKillChain(killChains, workingObjects, useKillChainPhaseName);
     const returnObjects = [];
     lodash.forEach(groupedObjects, killChainGroup => {
         const returnObject = calculateRiskByQuestion(killChainGroup.objects);
@@ -219,31 +291,40 @@ const riskPerKillChain = controller.getByIdCb((err, result, req, res, id) => { /
             const courseOfActions = results[0]
                 .filter(doc => doc !== undefined)
                 .map(doc => ({
-                    ...doc.toObject().stix,
-                    ...doc.toObject().metaProperties
+                    ...doc.stix,
+                    ...doc.metaProperties
                 }));
             const coaRisks = [];
 
             const indicators = results[1]
                 .filter(doc => doc !== undefined)
                 .map(doc => ({
-                    ...doc.toObject().stix,
-                    ...doc.toObject().metaProperties
+                    ...doc.stix,
+                    ...doc.metaProperties
                 }));
             const indicatorRisks = [];
 
             const sensors = results[2]
                 .filter(doc => doc !== undefined)
                 .map(doc => ({
-                    ...doc.toObject().stix,
-                    ...doc.toObject().metaProperties
+                    ...doc.stix,
+                    ...doc.metaProperties
                 }));
             const sensorRisks = [];
+
+            const capabilities = results[3]
+                .filter(doc => doc !== undefined)
+                .map(doc => ({
+                    ...doc.stix,
+                    ...doc.metaProperties
+                }));
+            const capabilityRisks = [];
 
             const returnObject = {};
             returnObject.indicators = [];
             returnObject.sensors = [];
             returnObject.courseOfActions = [];
+            returnObject.capabilities = [];
             lodash.forEach(indicators, stix => {
                 const assessedObject = lodash.find(assessment.assessment_objects, o => o.stix.id === stix.id);
                 const stixObject = stix;
@@ -265,6 +346,13 @@ const riskPerKillChain = controller.getByIdCb((err, result, req, res, id) => { /
                 stixObject.questions = assessedObject.questions;
                 sensorRisks.push(stixObject);
             });
+            lodash.forEach(capabilities, stix => {
+                const assessedObject = lodash.find(assessment.assessment_objects, o => o.stix.id === stix.id);
+                const stixObject = stix;
+                stixObject.risk = assessedObject.risk;
+                stixObject.questions = assessedObject.questions;
+                capabilityRisks.push(stixObject);
+            });
             if (indicators.length > 0) {
                 returnObject.indicators = calculateRiskPerKillChain(indicatorRisks, true);
             }
@@ -274,6 +362,9 @@ const riskPerKillChain = controller.getByIdCb((err, result, req, res, id) => { /
 
             if (courseOfActions.length > 0) {
                 returnObject.courseOfActions = calculateRiskPerKillChain(coaRisks, false);
+            }
+            if (capabilities.length > 0) {
+                returnObject.capabilities = calculateRiskPerKillChain(capabilityRisks, true);
             }
             const requestedUrl = apiRoot + req.originalUrl;
             res.header('Content-Type', 'application/json');

--- a/unfetter-discover-api/api/swagger/definitions/assessments/risk-per-kill-chain.yaml
+++ b/unfetter-discover-api/api/swagger/definitions/assessments/risk-per-kill-chain.yaml
@@ -12,4 +12,8 @@
       type: array
       items:
         $ref: ./risk-assessment-object.yaml
+    capabilities:
+      type: array
+      items:
+        $ref: ./risk-assessment-object.yaml
 


### PR DESCRIPTION
REQUIRES: https://github.com/unfetter-discover/unfetter-ui/pull/533

Should return risk-per-kill-chain information for capability type assessments.

To Test:
- Insure that above PR branch is checked out or merged into develop and running
- Create an assessment including the Capabilities category and complete assessing one or more capabilities.
- Take note of the id for the capabilities part of the assessment (should be like: x-unfetter-assessment--<hex-string-goes-here>)
- In the API explorer, exercise the risk-per-kill-chain endpoint with the id
- Should see 'capabilities' as one of the four returned types of 'data'
- Should see populated data in the capabilities type
- Populated data should include risk and objects; objects should include kill_chain_phases which should have "phase_name" and "kill_chain_name" populated.
