### PR TITLE
Added published attribute for display in baselines master list

### DIFF
--- a/unfetter-discover-api/api/controllers/x_unfetter_assessment_sets.js
+++ b/unfetter-discover-api/api/controllers/x_unfetter_assessment_sets.js
@@ -63,6 +63,7 @@ const latestAssessmentSetsByCreatorId = (req, res) => {
                 'stix.assessment_sets': {
                     $arrayElemAt: ['$stix.assessment_sets', 0]
                 },
+                'metaProperties.published': 1,
                 'stix.id': 1,
                 'stix.name': 1,
                 'stix.modified': 1,
@@ -75,6 +76,9 @@ const latestAssessmentSetsByCreatorId = (req, res) => {
                 _id: '$stix.id',
                 id: {
                     $push: '$stix.id'
+                },
+                published: {
+                    $first: '$metaProperties.published'
                 },
                 name: {
                     $first: '$stix.name'
@@ -137,6 +141,7 @@ const latestAssessmentSets = (req, res) => {
                 'stix.assessment_sets': {
                     $arrayElemAt: ['$stix.assessment_sets', 0]
                 },
+                'metaProperties.published': 1,
                 'stix.id': 1,
                 'stix.name': 1,
                 'stix.modified': 1,
@@ -149,6 +154,9 @@ const latestAssessmentSets = (req, res) => {
                 _id: '$stix.id',
                 id: {
                     $push: '$stix.id'
+                },
+                published: {
+                    $first: '$metaProperties.published'
                 },
                 name: {
                     $first: '$stix.name'


### PR DESCRIPTION
Supports unfetter-discover/unfetter#1147

The `published` attribute has been added to the `latest` assessment set API in order to provide this value to the baselines summary component.  It uses the value for display purposes in the baselines master list.

### To test:
1. Pull this branch
2. Display swagger API (no need to restart stack)
3. Run the x-unfetter-assessment-set `latest` or `latest/created_by_ref` APIs
4. Results should have the `published` flag in the results
