### PR TITLE
fixed indexes on user model to prevent duplicate null keys

### DIFF
--- a/unfetter-discover-api/api/models/user.js
+++ b/unfetter-discover-api/api/models/user.js
@@ -33,10 +33,12 @@ const UserSchema = new mongoose.Schema({
     },
     email: {
         type: String,
+        sparse: true,
         unique: true
     },
     userName: {
         type: String,
+        sparse: true,
         unique: true
     },
     registered: {
@@ -58,7 +60,8 @@ const UserSchema = new mongoose.Schema({
             'ORG_LEADER',
             'ADMIN'
         ],
-        default: 'STANDARD_USER'
+        default: 'STANDARD_USER',
+        index: true
     },
     oauth: String,
     github: {
@@ -67,6 +70,7 @@ const UserSchema = new mongoose.Schema({
         },
         id: {
             type: String,
+            unique: true,
             sparse: true
         },
         avatar_url: {
@@ -79,6 +83,7 @@ const UserSchema = new mongoose.Schema({
         },
         id: {
             type: String,
+            unique: true,
             sparse: true
         },
         avatar_url: {
@@ -132,8 +137,4 @@ const UserSchema = new mongoose.Schema({
     }
 });
 
-UserSchema.index({ userName: 1 });
-UserSchema.index({ role: 1 });
-
 module.exports = mongoose.model('User', UserSchema, 'user');
-// const User = module.exports;


### PR DESCRIPTION
Requirements:
- 2 github or gitlab user accounts

Instructions:
- In a mongo shell, `db.getCollection('user').dropIndexes()`
- Restart stack
- Register with a user that isn't the first of his auth service (ie, the 2nd github user to join the site) - This may require you to delete your secondary account
- Ensure registration occurs as expected

fixes unfetter-discover/unfetter#1218