### PR TITLE
Corrects threat ingest synchronization

### DIFF
--- a/unfetter-threat-ingest/src/models/server-state.ts
+++ b/unfetter-threat-ingest/src/models/server-state.ts
@@ -21,9 +21,27 @@ export class PromisedService<T> {
     }
 }
 
+export interface FeedSource {
+    name: string;
+    source: string | {
+        protocol: string;
+        host: string;
+        port: number;
+        path: string;
+    };
+    parser: any;
+    active?: boolean;
+}
+
+export interface DaemonConfiguration {
+    [key: string]: any;
+    feedSources?: FeedSource[];
+    debug?: boolean;
+}
+
 export class DaemonState {
 
-    public configuration: any = {};
+    public configuration: DaemonConfiguration = {};
 
     public readonly db: {
         conn?: Connection;


### PR DESCRIPTION
Fixes unfetter-discover/unfetter#1461.

Polls feeds, then updates boards, with one board update instead of saving for each report found.

- Make sure you have configured a "feedSource" type in the database. Sample one provided for convenience:
```
{
    "configGroups" : [ "feed" ],
    "configKey" : "feedSources",
    "configValue" : [ 
        {
            "name" : "DoD News Feed",
            "source" : "https://dod.defense.gov/DesktopModules/ArticleCS/RSS.ashx?ContentType=1&Site=727&max=10",
            "parser" : {
                "type" : "xml",
                "root" : "rss/channel",
                "articles" : "item",
                "convert" : {
                    "name" : "title",
                    "description" : "description",
                    "labels" : {
                        "element" : "category",
                        "arity" : true
                    },
                    "published" : {
                        "element" : "pubDate",
                        "type" : "date"
                    },
                    "metaProperties" : {
                        "link" : "link",
                        "image" : "enclosure@url"
                    }
                }
            },
            "active" : true
        }
    ]
}
```

- Make sure you have a threat board defined in the database. This service still doesn't aggregate board criteria references, so for now, use a malware or target value et al like "Military Operations" or "News" (you can try the URL above to see some sample values).

- The service is still not in a container or part of an ansible playbook (next time), so start the service with `cd unfetter-threat-ingest && npm install && npm run build && node dist/server/server.js`

The logs should show actions in sequence: Polling, polls completed, updated board.