### PR TITLE
Normalizing threat board boundaries for ingest matching

### DIFF
--- a/unfetter-threat-ingest/src/models/server-state.ts
+++ b/unfetter-threat-ingest/src/models/server-state.ts
@@ -2,6 +2,7 @@ import { Server } from 'https';
 import { Connection } from 'mongoose';
 import { BehaviorSubject } from 'rxjs';
 import * as yargs from 'yargs';
+
 import { ThreatFeedParsers } from '../processor/threat-feed-parser';
 
 export type RefreshFunction = (state: DaemonState, options?: yargs.Arguments) => void;

--- a/unfetter-threat-ingest/src/plugins/threat-feed-dod-news-demo-parser.ts
+++ b/unfetter-threat-ingest/src/plugins/threat-feed-dod-news-demo-parser.ts
@@ -49,7 +49,6 @@ class ThreatFeedDodNewsParser extends ThreatFeedXMLParser {
     };
 
     private isInReport = (report: ReportJSON, entry: any) => {
-        console.debug('comparing', entry.stix.name, 'to', report.stix.labels);
         return report.stix.labels.includes(entry.stix.name);
     }
 

--- a/unfetter-threat-ingest/src/plugins/threat-feed-dod-news-demo-parser.ts
+++ b/unfetter-threat-ingest/src/plugins/threat-feed-dod-news-demo-parser.ts
@@ -1,0 +1,58 @@
+import { DaemonState } from '../models/server-state';
+import ReportJSON from '../processor/report-json';
+import { ThreatFeedXMLParser } from '../processor/threat-feed-xml-parser';
+
+/**
+ * This is a demo of using the plugins module to inject new parsers into the ingest service. This parser is just a
+ * default XML parser, but adds a matcher to compare the threat board's boundary values against any labels we read.
+ */
+class ThreatFeedDodNewsParser extends ThreatFeedXMLParser {
+
+    constructor() {
+        super('DoD-News-Demo');
+    }
+
+    /**
+     * Overrides the configuration for one we know matches the DoD News RSS Feed.
+     */
+    public parse(data: string, feed: any, state: DaemonState): Promise<ReportJSON[]> {
+        return super.parse(data, {
+            ...feed,
+            'parser' : {
+                'root' : 'rss/channel',
+                'articles' : 'item',
+                'convert' : {
+                    'name' : 'title',
+                    'labels' : 'category',
+                    'published' : {
+                        'element' : 'pubDate',
+                        'type' : 'date'
+                    },
+                    'metaProperties' : {
+                        'link' : 'link',
+                        'image' : 'enclosure@url'
+                    }
+                }
+            }
+        }, state);
+    }
+
+    /**
+     * See class comment.
+     */
+    public match = (report: ReportJSON, board: any): boolean => {
+        return ((board.stix.boundaries.start_date <= report.stix.published) &&
+                (!board.stix.boundaries.end_date || (board.stix.boundaries.end_date >= report.stix.published)) &&
+                (board.stix.boundaries.targets.some((target: any) => this.isInReport(report, target)) ||
+                    board.stix.boundaries.malware.some((malware: any) => this.isInReport(report, malware)) ||
+                    board.stix.boundaries.intrusion_sets.some((intrusion: any) => this.isInReport(report, intrusion))));
+    };
+
+    private isInReport = (report: ReportJSON, entry: any) => {
+        console.debug('comparing', entry.stix.name, 'to', report.stix.labels);
+        return report.stix.labels.includes(entry.stix.name);
+    }
+
+}
+
+(() => new ThreatFeedDodNewsParser())();

--- a/unfetter-threat-ingest/src/processor/threat-feed-xml-parser.ts
+++ b/unfetter-threat-ingest/src/processor/threat-feed-xml-parser.ts
@@ -5,10 +5,10 @@ import ReportJSON from './report-json';
 
 const XMLParser = new xml2js.Parser();
 
-class ThreatFeedXMLParser extends ThreatFeedParser {
+export class ThreatFeedXMLParser extends ThreatFeedParser {
 
-    constructor() {
-        super('XML');
+    constructor(_type: string) {
+        super(_type || 'XML');
     }
 
     public parse(data: string, feed: any, state: DaemonState): Promise<ReportJSON[]> {
@@ -244,4 +244,4 @@ class ThreatFeedXMLParser extends ThreatFeedParser {
 
 }
 
-(() => new ThreatFeedXMLParser())();
+(() => new ThreatFeedXMLParser(null))();


### PR DESCRIPTION
Fixes unfetter-discover/unfetter#1473.

Populates threat board references.
Also, adds optional threat board matching ability to feed parsers.
Created a demo parser in plugins module for DoD News RSS feed. Rather than just matching on date range, this plugin will compare potential reports to other threat boundaries (malware, targets and intrusion sets) by name.

- Create a threat actor or malware or intrusion set that matches one of the DoD News feed categories, such as:
```
{
    "_id" : "threat-actor--8e2e2d2b-17d4-4cbf-938f-98ee46b3cd40",
    "stix" : {
        "type" : "threat-actor",
        "id" : "threat-actor--8e2e2d2b-17d4-4cbf-938f-98ee46b3cd40",
        "created_by_ref" : "identity--f431f809-377b-45e0-aa1c-6a4751cae5ff",
        "created" : ISODate("2018-09-28T00:00:01.000Z"),
        "labels" : [],
        "name" : "Military Operations",
        "description" : "Military Operations",
        "aliases" : [],
        "roles" : "director",
        "goals" : [],
        "sophistication" : "advanced",
        "resource_level" : "team",
        "primary_motivation" : "organizational-gain"
    },
    "__v" : 0
}
```

- Create a threat board in the database, assigning the above reference to its boundaries. Here's a sample:
```
{
    "_id" : "x-unfetter-threat-board--b6974637-3258-4041-b70c-74693f0cfdb5",
    "metaProperties" : {
    },
    "stix" : {
        "type" : "x-unfetter-threat-board",
        "id" : "x-unfetter-threat-board--b6974637-3258-4041-b70c-74693f0cfdb5",
        "name" : "DoD News Articles about Bob",
        "created" : ISODate("2018-09-19T00:00:01.000Z"),
        "created_by_ref" : "identity--e240b257-5c42-402e-a0e8-7b81ecc1c09a",
        "description" : "The attacks against Bob, according to the DoD",
        "boundaries" : {
            "start_date" : ISODate("2018-09-01T00:00:00.000Z"),
            "end_date" : ISODate("2019-01-01T00:00:00.000Z"),
            "targets" : ["threat-actor--8e2e2d2b-17d4-4cbf-938f-98ee46b3cd40"],
            "intrusion_sets" : [],
            "malware" : []
        },
        "reports" : [],
        "articles" : [],
        "external_references" : [],
        "granular_markings" : [],
        "labels" : [],
        "modified" : ISODate("2018-09-20T18:43:48.794Z"),
        "object_marking_refs" : []
    },
    "__v" : 26
}
```

- Create a feedSource configuration in the database. Sample:
```
{
    "configGroups" : [ "feed" ],
    "configKey" : "feedSources",
    "configValue" : [ 
        {
            "name" : "DoD News Feed",
            "source" : "https://dod.defense.gov/DesktopModules/ArticleCS/RSS.ashx?ContentType=1&Site=727&max=10",
            "parser" : {
                "type" : "dod-news-demo"
            },
            "active" : true
        }
    ]
}
```

- Create a `unfetter-threat-ingest/config/.env` file in this directory. Example contents of the .env file:
```
{
    "cert-dir": "../unfetter/ansible/backup/certs-vol",
    "socket-server-port": 13333
}
```
Recommend setting a full path for the cert-dir, wherever the certs you use to bring up the stack are located.

- Make sure the database is running, at least, you don't need the full stack.

- The service is still not in a container, so you have to start it by hand: `cd unfetter-threat-ingest && npm install && npm run start`

- Assuming the feed pulls in at least one matching report (it may not, but we're asking for 10 news items, so there's a fair chance), the following should happen:
  - The threat board in the database should list 1 or more reports `db.getCollection('stix').find({'stix.type': 'x-unfetter-threat-board'})`,
  - The list of reports in the database should increase by the same amount. These reports will have a specific metadata to make it easier to query for just them: `db.getCollection('stix').find({'stix.type': 'report', 'metaProperties.source': {'$exists': true}})`