### PR TITLE
Moves ingested reports into the threat board meta properties

### DIFF
--- a/unfetter-threat-ingest/src/models/stix-commons.ts
+++ b/unfetter-threat-ingest/src/models/stix-commons.ts
@@ -10,6 +10,10 @@ stixCommons.metaProperties = new mongoose.Schema({
     lastPolled: {
         type: Number,
         required: false
+    },
+    potentials: {
+        type: [String],
+        default: []
     }
 }, { _id: false, strict: false });
 

--- a/unfetter-threat-ingest/src/models/threat-board.ts
+++ b/unfetter-threat-ingest/src/models/threat-board.ts
@@ -14,10 +14,7 @@ const StixSchema = {
         required: [true, 'name is required']
     },
     description: String,
-    created_by_ref: {
-        type: String,
-        required: [true, 'created_by_ref is required']
-    },
+    created_by_ref: String,
     boundaries: {
         start_date: {
             type: Date,

--- a/unfetter-threat-ingest/src/processor/threat-feed-processor.ts
+++ b/unfetter-threat-ingest/src/processor/threat-feed-processor.ts
@@ -7,7 +7,6 @@ import { ObjectId } from 'bson';
 import ReportJSON from './report-json';
 import { ThreatFeedParser } from './threat-feed-parser';
 import { DaemonState, StatusEnum } from '../models/server-state';
-import { isArray } from 'util';
 
 export default class ThreatFeedProcessor {
 
@@ -62,7 +61,9 @@ export default class ThreatFeedProcessor {
      * Fire the given request to a feed source.
      */
     private pollFeed(options: any) {
-        console.debug('calling feed', options);
+        if (this.state.configuration.debug) {
+            console.debug('calling feed', options);
+        }
         return new Promise((resolve, reject) => {
             const request = https.get(options, (res) => {
                 let output = '';
@@ -146,15 +147,10 @@ export default class ThreatFeedProcessor {
                 }, []);
                 if (matches.length) {
                     report.stix.id = `report--${uuid.v4()}`;
-                    matches.forEach((board: any) => {
-                        this.notifyBoard(board, report);
-                        if (!board.metaProperties) {
-                            board.metaProperties = {};
-                        }
-                        if (!isArray(board.metaProperties['potential-reports'])) {
-                            board.metaProperties['potential-reports'] = [];
-                        }
-                        board.metaProperties['potential-reports'].push(report.stix.id);
+                    matches.forEach((match) => {
+                        const board: any = match;
+                        this.notifyBoard(match, report);
+                        board.metaProperties.potentials.push(report.stix.id);
                     });
                     reports.push(report);
                 }
@@ -177,7 +173,7 @@ export default class ThreatFeedProcessor {
      * Send a notification to users of the given threat board that the given report is a possible match.
      */
     private notifyBoard(board: any, report: ReportJSON) {
-        if (this.state.configuration['fire-notifications'] !== true) {
+        if (this.state.configuration['fire-notifications'] === true) {
             const host = this.state.configuration['socket-server-host'];
             const port = this.state.configuration['socket-server-port'];
             const reference = `'${report.stix.name}' read from '${report.metaProperties.source}'`;

--- a/unfetter-threat-ingest/src/processor/threat-feed-processor.ts
+++ b/unfetter-threat-ingest/src/processor/threat-feed-processor.ts
@@ -7,6 +7,7 @@ import { ObjectId } from 'bson';
 import ReportJSON from './report-json';
 import { ThreatFeedParser } from './threat-feed-parser';
 import { DaemonState, StatusEnum } from '../models/server-state';
+import { isArray } from 'util';
 
 export default class ThreatFeedProcessor {
 
@@ -147,7 +148,13 @@ export default class ThreatFeedProcessor {
                     report.stix.id = `report--${uuid.v4()}`;
                     matches.forEach((board: any) => {
                         this.notifyBoard(board, report);
-                        board.stix.reports.push(report.stix.id);
+                        if (!board.metaProperties) {
+                            board.metaProperties = {};
+                        }
+                        if (!isArray(board.metaProperties['potential-reports'])) {
+                            board.metaProperties['potential-reports'] = [];
+                        }
+                        board.metaProperties['potential-reports'].push(report.stix.id);
                     });
                     reports.push(report);
                 }

--- a/unfetter-threat-ingest/src/server/processinit.ts
+++ b/unfetter-threat-ingest/src/server/processinit.ts
@@ -113,14 +113,12 @@ const afterPolling = (polledReports: any[], boards: Document[], state: DaemonSta
             /*
              * After all that, update each board to show they were recently polled for.
              */
-            boards.forEach((board) => {
-                if (!(board as any).metaProperties) {
-                    (board as any).metaProperties = {};
-                }
-                (board as any).metaProperties.lastPolled = Date.now();
-                board.save((err, tb) => {
+            boards.forEach((boardDoc) => {
+                const board: any = boardDoc;
+                board.metaProperties.lastPolled = Date.now();
+                boardDoc.save((err, tb) => {
                     if (err) {
-                        console.warn(`Could not update threat board '${(board as any).stix.name}':`, err);
+                        console.warn(`Could not update threat board '${(boardDoc as any).stix.name}':`, err);
                     } else {
                         if (state.configuration.debug) {
                             console.debug('Updated board', tb);

--- a/unfetter-threat-ingest/src/server/processinit.ts
+++ b/unfetter-threat-ingest/src/server/processinit.ts
@@ -114,6 +114,9 @@ const afterPolling = (polledReports: any[], boards: Document[], state: DaemonSta
              * After all that, update each board to show they were recently polled for.
              */
             boards.forEach((board) => {
+                if (!(board as any).metaProperties) {
+                    (board as any).metaProperties = {};
+                }
                 (board as any).metaProperties.lastPolled = Date.now();
                 board.save((err, tb) => {
                     if (err) {
@@ -126,7 +129,7 @@ const afterPolling = (polledReports: any[], boards: Document[], state: DaemonSta
                 });
             });
         })
-        .catch((reason) => console.log('Report save failed????', reason))
+        .catch((reason) => console.log('Board save failed????', reason))
 }
 
 /**


### PR DESCRIPTION
Fixes unfetter-discover/unfetter#1484.

Moves the ingested reports into the metadata instead of the reports array.