### PR TITLE
Fixes datatype of lastPolled metaProperty

### DIFF
--- a/unfetter-threat-ingest/src/models/stix-commons.ts
+++ b/unfetter-threat-ingest/src/models/stix-commons.ts
@@ -8,7 +8,7 @@ stixCommons.metaProperties = new mongoose.Schema({
         default: false
     },
     lastPolled: {
-        type: Number,
+        type: Date,
         required: false
     },
     potentials: {
@@ -73,7 +73,8 @@ stixCommons.baseStix = {
     },
     created_by_ref: {
         type: String,
-        index: 1
+        index: 1,
+        required: false
     },
     revoked: Boolean,
     version: String,


### PR DESCRIPTION
Changes lastPolled from Number to Date.

Not much to test for. Start stack. Confirm threat ingest service running okay (`docker logs -f unfetter-threat-ingest`). Check stix collection for threatboards' lastPolled value.