### PR TITLE
Dereferencing created_by_ref for threatboards

### DIFF
--- a/unfetter-discover-api/api/express-controllers/auth.js
+++ b/unfetter-discover-api/api/express-controllers/auth.js
@@ -148,6 +148,7 @@ router.get('/get-user-list',
                         _id: user._id,
                         attributes: {
                             _id: user._id,
+                            id: user.identity.id,
                             userName: user.userName,
                             firstName: user.firstName,
                             lastName: user.lastName,


### PR DESCRIPTION
Supports unfetter-discover/unfetter#1490.

Adds user's identity.id to returned user list, so that created_by_ref's can be dereferenced.

See https://github.com/unfetter-discover/unfetter-ui/pull/664