### PR TITLE
Stops treating targets as references

### DIFF
--- a/unfetter-threat-ingest/src/plugins/threat-feed-dod-news-demo-parser.ts
+++ b/unfetter-threat-ingest/src/plugins/threat-feed-dod-news-demo-parser.ts
@@ -41,15 +41,16 @@ class ThreatFeedDodNewsParser extends ThreatFeedXMLParser {
      * See class comment.
      */
     public match = (report: ReportJSON, board: any): boolean => {
-        return ((board.stix.boundaries.start_date.getTime() <= report.stix.published) &&
-                (!board.stix.boundaries.end_date || (board.stix.boundaries.end_date.getTime() >= report.stix.published)) &&
-                (board.stix.boundaries.targets.some((target: any) => this.isInReport(report, target)) ||
-                    board.stix.boundaries.malware.some((malware: any) => this.isInReport(report, malware)) ||
-                    board.stix.boundaries.intrusion_sets.some((intrusion: any) => this.isInReport(report, intrusion))));
+        const bounds = board.stix.boundaries;
+        return ((bounds.start_date.getTime() <= report.stix.published) &&
+                (!bounds.end_date || (bounds.end_date.getTime() >= report.stix.published)) &&
+                (bounds.targets.some((target: any) => this.isInReport(report, target)) ||
+                        bounds.malware.some((malware: any) => this.isInReport(report, malware.stix.name)) ||
+                        bounds.intrusion_sets.some((intrusion: any) => this.isInReport(report, intrusion.stix.name))));
     };
 
     private isInReport = (report: ReportJSON, entry: any) => {
-        return report.stix.labels.includes(entry.stix.name);
+        return report.stix.labels.includes(entry);
     }
 
 }

--- a/unfetter-threat-ingest/src/server/processinit.ts
+++ b/unfetter-threat-ingest/src/server/processinit.ts
@@ -40,7 +40,6 @@ const poll = (state: DaemonState) => {
     promises.push(ThreatBoardModel
         .find({'stix.type': 'x-unfetter-threat-board'})
         .populate('stix.boundaries.intrusion_sets')
-        .populate('stix.boundaries.targets')
         .populate('stix.boundaries.malware')
         .exec());
     Promise.all(promises)


### PR DESCRIPTION
Threat ingest service was attempting to look up STIX objects for targets listed in the threatboard boundaries. The targets array does not reference STIX objects, it's just an array of string values. Te dereferencing has been removed.