### PR TITLE
Enforces node-fetch version

### DIFF
--- a/unfetter-threat-ingest/package-lock.json
+++ b/unfetter-threat-ingest/package-lock.json
@@ -5,107 +5,113 @@
     "requires": true,
     "dependencies": {
         "@babel/code-frame": {
-            "version": "7.0.0-beta.51",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.51.tgz",
-            "integrity": "sha1-vXHZsZKvl435FYKdOdQJRFZDmgw=",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+            "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
             "dev": true,
             "requires": {
-                "@babel/highlight": "7.0.0-beta.51"
+                "@babel/highlight": "^7.0.0"
             }
         },
         "@babel/generator": {
-            "version": "7.0.0-beta.51",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.51.tgz",
-            "integrity": "sha1-bHV1/952HQdIXgS67cA5LG2eMPY=",
+            "version": "7.1.6",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.1.6.tgz",
+            "integrity": "sha512-brwPBtVvdYdGxtenbQgfCdDPmtkmUBZPjUoK5SXJEBuHaA5BCubh9ly65fzXz7R6o5rA76Rs22ES8Z+HCc0YIQ==",
             "dev": true,
             "requires": {
-                "@babel/types": "7.0.0-beta.51",
+                "@babel/types": "^7.1.6",
                 "jsesc": "^2.5.1",
-                "lodash": "^4.17.5",
+                "lodash": "^4.17.10",
                 "source-map": "^0.5.0",
                 "trim-right": "^1.0.1"
             }
         },
         "@babel/helper-function-name": {
-            "version": "7.0.0-beta.51",
-            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.51.tgz",
-            "integrity": "sha1-IbSHSiJ8+Z7K/MMKkDAtpaJkBWE=",
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+            "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
             "dev": true,
             "requires": {
-                "@babel/helper-get-function-arity": "7.0.0-beta.51",
-                "@babel/template": "7.0.0-beta.51",
-                "@babel/types": "7.0.0-beta.51"
+                "@babel/helper-get-function-arity": "^7.0.0",
+                "@babel/template": "^7.1.0",
+                "@babel/types": "^7.0.0"
             }
         },
         "@babel/helper-get-function-arity": {
-            "version": "7.0.0-beta.51",
-            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.51.tgz",
-            "integrity": "sha1-MoGy0EWvlcFyzpGyCCXYXqRnZBE=",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+            "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
             "dev": true,
             "requires": {
-                "@babel/types": "7.0.0-beta.51"
+                "@babel/types": "^7.0.0"
             }
         },
         "@babel/helper-split-export-declaration": {
-            "version": "7.0.0-beta.51",
-            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.51.tgz",
-            "integrity": "sha1-imw/ZsTSZTUvwHdIT59ugKUauXg=",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz",
+            "integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
             "dev": true,
             "requires": {
-                "@babel/types": "7.0.0-beta.51"
+                "@babel/types": "^7.0.0"
             }
         },
         "@babel/highlight": {
-            "version": "7.0.0-beta.51",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.51.tgz",
-            "integrity": "sha1-6IRK4loVlcz9QriWI7Q3bKBtIl0=",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+            "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
             "dev": true,
             "requires": {
                 "chalk": "^2.0.0",
                 "esutils": "^2.0.2",
-                "js-tokens": "^3.0.0"
+                "js-tokens": "^4.0.0"
+            },
+            "dependencies": {
+                "js-tokens": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+                    "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+                    "dev": true
+                }
             }
         },
         "@babel/parser": {
-            "version": "7.0.0-beta.51",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.51.tgz",
-            "integrity": "sha1-J87C30Cd9gr1gnDtj2qlVAnqhvY=",
+            "version": "7.1.6",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.1.6.tgz",
+            "integrity": "sha512-dWP6LJm9nKT6ALaa+bnL247GHHMWir3vSlZ2+IHgHgktZQx0L3Uvq2uAWcuzIe+fujRsYWBW2q622C5UvGK9iQ==",
             "dev": true
         },
         "@babel/template": {
-            "version": "7.0.0-beta.51",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.51.tgz",
-            "integrity": "sha1-lgKkCuvPNXrpZ34lMu9fyBD1+/8=",
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.1.2.tgz",
+            "integrity": "sha512-SY1MmplssORfFiLDcOETrW7fCLl+PavlwMh92rrGcikQaRq4iWPVH0MpwPpY3etVMx6RnDjXtr6VZYr/IbP/Ag==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "7.0.0-beta.51",
-                "@babel/parser": "7.0.0-beta.51",
-                "@babel/types": "7.0.0-beta.51",
-                "lodash": "^4.17.5"
+                "@babel/code-frame": "^7.0.0",
+                "@babel/parser": "^7.1.2",
+                "@babel/types": "^7.1.2"
             }
         },
         "@babel/traverse": {
-            "version": "7.0.0-beta.51",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.51.tgz",
-            "integrity": "sha1-mB2vLOw0emIx06odnhgDsDqqpKg=",
+            "version": "7.1.6",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.1.6.tgz",
+            "integrity": "sha512-CXedit6GpISz3sC2k2FsGCUpOhUqKdyL0lqNrImQojagnUMXf8hex4AxYFRuMkNGcvJX5QAFGzB5WJQmSv8SiQ==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "7.0.0-beta.51",
-                "@babel/generator": "7.0.0-beta.51",
-                "@babel/helper-function-name": "7.0.0-beta.51",
-                "@babel/helper-split-export-declaration": "7.0.0-beta.51",
-                "@babel/parser": "7.0.0-beta.51",
-                "@babel/types": "7.0.0-beta.51",
-                "debug": "^3.1.0",
+                "@babel/code-frame": "^7.0.0",
+                "@babel/generator": "^7.1.6",
+                "@babel/helper-function-name": "^7.1.0",
+                "@babel/helper-split-export-declaration": "^7.0.0",
+                "@babel/parser": "^7.1.6",
+                "@babel/types": "^7.1.6",
+                "debug": "^4.1.0",
                 "globals": "^11.1.0",
-                "invariant": "^2.2.0",
-                "lodash": "^4.17.5"
+                "lodash": "^4.17.10"
             },
             "dependencies": {
                 "debug": {
-                    "version": "3.2.5",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
-                    "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
+                    "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
                     "dev": true,
                     "requires": {
                         "ms": "^2.1.1"
@@ -120,13 +126,13 @@
             }
         },
         "@babel/types": {
-            "version": "7.0.0-beta.51",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.51.tgz",
-            "integrity": "sha1-2AK3tUO1g2x3iqaReXq/APPZfqk=",
+            "version": "7.1.6",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.1.6.tgz",
+            "integrity": "sha512-DMiUzlY9DSjVsOylJssxLHSgj6tWM9PRFJOGW/RaOglVOK9nzTxoOMfTfRQXGUCUQ/HmlG2efwC+XqUEJ5ay4w==",
             "dev": true,
             "requires": {
                 "esutils": "^2.0.2",
-                "lodash": "^4.17.5",
+                "lodash": "^4.17.10",
                 "to-fast-properties": "^2.0.0"
             }
         },
@@ -160,7 +166,7 @@
         },
         "@types/events": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@types/events/-/events-1.2.0.tgz",
+            "resolved": "http://registry.npmjs.org/@types/events/-/events-1.2.0.tgz",
             "integrity": "sha512-KEIlhXnIutzKwRbQkGWb/I4HFqBuUykAdHgDED6xqwXJfONCjF5VoE0cXEiurh3XauygxzeDzgtXUqvLkxFzzA==",
             "dev": true
         },
@@ -196,9 +202,9 @@
             }
         },
         "@types/glob": {
-            "version": "5.0.35",
-            "resolved": "https://registry.npmjs.org/@types/glob/-/glob-5.0.35.tgz",
-            "integrity": "sha512-wc+VveszMLyMWFvXLkloixT4n0harUIVZjnpzztaZ0nKLuul7Z32iMt2fUFGAaZ4y1XWjFRMtCI5ewvyh4aIeg==",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
+            "integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
             "dev": true,
             "requires": {
                 "@types/events": "*",
@@ -219,21 +225,21 @@
             "dev": true
         },
         "@types/jasmine": {
-            "version": "2.8.9",
-            "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-2.8.9.tgz",
-            "integrity": "sha512-8dPZwjosElZOGGYw1nwTvOEMof4gjwAWNFS93nBI091BoEfd5drnHOLRMiRF/LOPuMTn5LgEdv0bTUO8QFVuHQ==",
+            "version": "2.8.12",
+            "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-2.8.12.tgz",
+            "integrity": "sha512-eE+xeiGBPgQsNcyg61JBqQS6NtxC+s2yfOikMCnc0Z4NqKujzmSahmtjLCKVQU/AyrTEQ76TOwQBnr8wGP2bmA==",
             "dev": true
         },
         "@types/lodash": {
-            "version": "4.14.116",
-            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.116.tgz",
-            "integrity": "sha512-lRnAtKnxMXcYYXqOiotTmJd74uawNWuPnsnPrrO7HiFuE3npE2iQhfABatbYDyxTNqZNuXzcKGhw37R7RjBFLg==",
+            "version": "4.14.118",
+            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.118.tgz",
+            "integrity": "sha512-iiJbKLZbhSa6FYRip/9ZDX6HXhayXLDGY2Fqws9cOkEQ6XeKfaxB0sC541mowZJueYyMnVUmmG+al5/4fCDrgw==",
             "dev": true
         },
         "@types/marked": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/@types/marked/-/marked-0.4.1.tgz",
-            "integrity": "sha512-ZqEGxppVG1x9QK/hkHxzmf6m4xcnk9CaHjNCqwvUeN3pMdCcQkPxmvrbLZ5GbP7K25TgiT1nKIGnz0U3M+G05Q==",
+            "version": "0.4.2",
+            "resolved": "https://registry.npmjs.org/@types/marked/-/marked-0.4.2.tgz",
+            "integrity": "sha512-cDB930/7MbzaGF6U3IwSQp6XBru8xWajF5PV2YZZeV8DyiliTuld11afVztGI9+yJZ29il5E+NpGA6ooV/Cjkg==",
             "dev": true
         },
         "@types/mime": {
@@ -249,31 +255,29 @@
             "dev": true
         },
         "@types/mongodb": {
-            "version": "3.1.7",
-            "resolved": "https://registry.npmjs.org/@types/mongodb/-/mongodb-3.1.7.tgz",
-            "integrity": "sha512-ljS4mE9o3apEkI59pftdnLf3b1ZczMPtXWp1myrhR+E/CLk0O5SjbTt6Rn3OxMB+Qc2eAytrQVufa4y1pFqE2A==",
+            "version": "3.1.14",
+            "resolved": "https://registry.npmjs.org/@types/mongodb/-/mongodb-3.1.14.tgz",
+            "integrity": "sha512-Hc9nhu9Z33Gq8SP2CZluNlhwbXBCEGAzLMQPEceZG0wUt/ZTzIGaeo8RXu7FWNXfUd6JHh6KHl0YjQlu6TgncQ==",
             "dev": true,
             "requires": {
                 "@types/bson": "*",
-                "@types/events": "*",
                 "@types/node": "*"
             }
         },
         "@types/mongoose": {
-            "version": "5.2.15",
-            "resolved": "https://registry.npmjs.org/@types/mongoose/-/mongoose-5.2.15.tgz",
-            "integrity": "sha512-l+im3h63sWbL/9UDXAzQ64fztw/vrHtQU2O/0VdRXTDcNji9Q7dJmAD6OPEx/1Pzpj2vTIsmH3Wky5+rkfWmmg==",
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/@types/mongoose/-/mongoose-5.3.1.tgz",
+            "integrity": "sha512-4ASViFpeE9LLE+VLs/NgPy1gSS6nlUA5Iz9UBm1X5VMLqgGURvGfqML3liRrzna6WUt5kNTcLf245GQHxCxuBQ==",
             "dev": true,
             "requires": {
-                "@types/events": "*",
                 "@types/mongodb": "*",
                 "@types/node": "*"
             }
         },
         "@types/node": {
-            "version": "10.10.1",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.10.1.tgz",
-            "integrity": "sha512-nzsx28VwfaIykfzMAG9TB3jxF5Nn+1/WMKnmVZc8TsB+LMIVvwUscVn7PAq+LFaY5ng5u4jp5mRROSswo76PPA==",
+            "version": "10.12.9",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.9.tgz",
+            "integrity": "sha512-eajkMXG812/w3w4a1OcBlaTwsFPO5F7fJ/amy+tieQxEMWBlbV1JGSjkFM+zkHNf81Cad+dfIRA+IBkvmvdAeA==",
             "dev": true
         },
         "@types/node-fetch": {
@@ -331,9 +335,9 @@
             }
         },
         "@types/yargs": {
-            "version": "12.0.0",
-            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-12.0.0.tgz",
-            "integrity": "sha512-GTSFHeTWamRTKaApG47hgWsZWrjsw6PJSfrgntA9WAXKFUvjHi6Evf2JL0NkZNIKIX1Xi5wtV9sXMNJSC/O3Tw==",
+            "version": "12.0.1",
+            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-12.0.1.tgz",
+            "integrity": "sha512-UVjo2oH79aRNcsDlFlnQ/iJ67Jd7j6uSg7jUJP/RZ/nUjAh5ElmnwlD5K/6eGgETJUgCHkiWn91B8JjXQ6ubAw==",
             "dev": true
         },
         "abbrev": {
@@ -361,9 +365,9 @@
             }
         },
         "ansi-regex": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-            "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "ansi-styles": {
             "version": "3.2.1",
@@ -462,11 +466,6 @@
                 "js-tokens": "^3.0.2"
             },
             "dependencies": {
-                "ansi-regex": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-                },
                 "ansi-styles": {
                     "version": "2.2.1",
                     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
@@ -482,14 +481,6 @@
                         "has-ansi": "^2.0.0",
                         "strip-ansi": "^3.0.0",
                         "supports-color": "^2.0.0"
-                    }
-                },
-                "strip-ansi": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                    "requires": {
-                        "ansi-regex": "^2.0.0"
                     }
                 },
                 "supports-color": {
@@ -571,20 +562,20 @@
             "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw="
         },
         "body-parser": {
-            "version": "1.18.2",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
-            "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+            "version": "1.18.3",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
+            "integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
             "requires": {
                 "bytes": "3.0.0",
                 "content-type": "~1.0.4",
                 "debug": "2.6.9",
-                "depd": "~1.1.1",
-                "http-errors": "~1.6.2",
-                "iconv-lite": "0.4.19",
+                "depd": "~1.1.2",
+                "http-errors": "~1.6.3",
+                "iconv-lite": "0.4.23",
                 "on-finished": "~2.3.0",
-                "qs": "6.5.1",
-                "raw-body": "2.3.2",
-                "type-is": "~1.6.15"
+                "qs": "6.5.2",
+                "raw-body": "2.3.3",
+                "type-is": "~1.6.16"
             }
         },
         "boxen": {
@@ -600,6 +591,14 @@
                 "string-width": "^2.0.0",
                 "term-size": "^1.2.0",
                 "widest-line": "^2.0.0"
+            },
+            "dependencies": {
+                "camelcase": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+                    "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+                    "dev": true
+                }
             }
         },
         "brace-expansion": {
@@ -684,9 +683,9 @@
             }
         },
         "camelcase": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-            "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
+            "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA=="
         },
         "capture-stack-trace": {
             "version": "1.0.1",
@@ -702,16 +701,6 @@
                 "ansi-styles": "^3.2.1",
                 "escape-string-regexp": "^1.0.5",
                 "supports-color": "^5.3.0"
-            },
-            "dependencies": {
-                "supports-color": {
-                    "version": "5.5.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-                    "requires": {
-                        "has-flag": "^3.0.0"
-                    }
-                }
             }
         },
         "chokidar": {
@@ -736,9 +725,9 @@
             }
         },
         "ci-info": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.5.1.tgz",
-            "integrity": "sha512-fKFIKXaYiL1exImwJ0AhR/6jxFPSKQBk2ayV5NiNoruUs2+rxC2kNw0EG+1Z9dugZRdCrppskQ8DN2cyaUM1Hw==",
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
+            "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
             "dev": true
         },
         "class-utils": {
@@ -778,6 +767,21 @@
                 "string-width": "^2.1.1",
                 "strip-ansi": "^4.0.0",
                 "wrap-ansi": "^2.0.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "requires": {
+                        "ansi-regex": "^3.0.0"
+                    }
+                }
             }
         },
         "code-point-at": {
@@ -810,14 +814,14 @@
         },
         "colors": {
             "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+            "resolved": "http://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
             "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
             "dev": true
         },
         "commander": {
-            "version": "2.18.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.18.0.tgz",
-            "integrity": "sha512-6CYPa+JP2ftfRU2qkDK+UTVeQYosOg/2GbcjIcKPHfinyOLPVGXu/ovN86RP49Re5ndJK1N0kuiidFFuepc4ZQ=="
+            "version": "2.19.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
+            "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg=="
         },
         "component-emitter": {
             "version": "1.2.1",
@@ -831,29 +835,35 @@
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "concurrently": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-4.0.1.tgz",
-            "integrity": "sha512-D8UI+mlI/bfvrA57SeKOht6sEpb01dKk+8Yee4fbnkk1Ue8r3S+JXoEdFZIpzQlXJGtnxo47Wvvg/kG4ba3U6Q==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-4.1.0.tgz",
+            "integrity": "sha512-pwzXCE7qtOB346LyO9eFWpkFJVO3JQZ/qU/feGeaAHiX1M3Rw3zgXKc5cZ8vSH5DGygkjzLFDzA/pwoQDkRNGg==",
             "dev": true,
             "requires": {
                 "chalk": "^2.4.1",
                 "date-fns": "^1.23.0",
                 "lodash": "^4.17.10",
                 "read-pkg": "^4.0.1",
-                "rxjs": "6.2.2",
+                "rxjs": "^6.3.3",
                 "spawn-command": "^0.0.2-1",
                 "supports-color": "^4.5.0",
                 "tree-kill": "^1.1.0",
                 "yargs": "^12.0.1"
             },
             "dependencies": {
-                "rxjs": {
-                    "version": "6.2.2",
-                    "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.2.2.tgz",
-                    "integrity": "sha512-0MI8+mkKAXZUF9vMrEoPnaoHkfzBPP4IGwUYRJhIRJF6/w3uByO1e91bEHn8zd43RdkTMKiooYKmwz7RH6zfOQ==",
+                "has-flag": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+                    "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "4.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+                    "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
                     "dev": true,
                     "requires": {
-                        "tslib": "^1.9.0"
+                        "has-flag": "^2.0.0"
                     }
                 }
             }
@@ -945,12 +955,9 @@
             }
         },
         "decamelize": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-2.0.0.tgz",
-            "integrity": "sha512-Ikpp5scV3MSYxY39ymh45ZLEecsTdv/Xj2CaQfI8RLMuwi7XvjX9H/fhraiSuU+C5w5NTDu4ZU72xNiZnurBPg==",
-            "requires": {
-                "xregexp": "4.0.0"
-            }
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
         },
         "decode-uri-component": {
             "version": "0.2.0",
@@ -1162,13 +1169,13 @@
             }
         },
         "express": {
-            "version": "4.16.3",
-            "resolved": "http://registry.npmjs.org/express/-/express-4.16.3.tgz",
-            "integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
+            "version": "4.16.4",
+            "resolved": "https://registry.npmjs.org/express/-/express-4.16.4.tgz",
+            "integrity": "sha512-j12Uuyb4FMrd/qQAm6uCHAkPtO8FDTRJZBDd5D2KOL2eLaz1yUNdUB/NOIyq0iU4q4cFarsUCrnFDPBcnksuOg==",
             "requires": {
                 "accepts": "~1.3.5",
                 "array-flatten": "1.1.1",
-                "body-parser": "1.18.2",
+                "body-parser": "1.18.3",
                 "content-disposition": "0.5.2",
                 "content-type": "~1.0.4",
                 "cookie": "0.3.1",
@@ -1185,10 +1192,10 @@
                 "on-finished": "~2.3.0",
                 "parseurl": "~1.3.2",
                 "path-to-regexp": "0.1.7",
-                "proxy-addr": "~2.0.3",
-                "qs": "6.5.1",
+                "proxy-addr": "~2.0.4",
+                "qs": "6.5.2",
                 "range-parser": "~1.2.0",
-                "safe-buffer": "5.1.1",
+                "safe-buffer": "5.1.2",
                 "send": "0.16.2",
                 "serve-static": "1.13.2",
                 "setprototypeof": "1.1.0",
@@ -1196,13 +1203,6 @@
                 "type-is": "~1.6.16",
                 "utils-merge": "1.0.1",
                 "vary": "~1.1.2"
-            },
-            "dependencies": {
-                "safe-buffer": {
-                    "version": "5.1.1",
-                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-                    "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
-                }
             }
         },
         "extend-shallow": {
@@ -1316,7 +1316,7 @@
         },
         "finalhandler": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+            "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
             "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
             "requires": {
                 "debug": "2.6.9",
@@ -1337,9 +1337,9 @@
             }
         },
         "flatmap-stream": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/flatmap-stream/-/flatmap-stream-0.1.0.tgz",
-            "integrity": "sha512-Nlic4ZRYxikqnK5rj3YoxDVKGGtUjcNDUtvQ7XsdGLZmMwdUYnXf10o1zcXtzEZTBgc6GxeRpQxV/Wu3WPIIHA==",
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/flatmap-stream/-/flatmap-stream-0.1.2.tgz",
+            "integrity": "sha512-ucyr6WkLXjyMuHPtOUq4l+nSAxgWi7v4QO508eQ9resnGj+lSup26oIsUI5aH8k4Qfpjsxa8dDf9UCKkS2KHzQ==",
             "dev": true
         },
         "for-in": {
@@ -1374,9 +1374,9 @@
             "dev": true
         },
         "fs-extra": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.0.tgz",
-            "integrity": "sha512-EglNDLRpmaTWiD/qraZn6HREAEAHJcJOmxNEYwq6xeMKnVMAy3GUcFB+wXt2C6k4CNvB/mP1y/U3dzvKKj5OtQ==",
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+            "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
             "dev": true,
             "requires": {
                 "graceful-fs": "^4.1.2",
@@ -1925,7 +1925,7 @@
         },
         "get-stream": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+            "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
             "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
         },
         "get-value": {
@@ -1978,9 +1978,9 @@
             }
         },
         "globals": {
-            "version": "11.7.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
-            "integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg==",
+            "version": "11.9.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-11.9.0.tgz",
+            "integrity": "sha512-5cJVtyXWH8PiJPVLZzzoIizXx944O4OmRro5MWKx5fT4MgcN7OfaMutPeaTdJCCURwbWdhhcCWcKIffPnmTzBg==",
             "dev": true
         },
         "got": {
@@ -2003,9 +2003,9 @@
             }
         },
         "graceful-fs": {
-            "version": "4.1.11",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-            "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+            "version": "4.1.15",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+            "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
             "dev": true
         },
         "handlebars": {
@@ -2034,13 +2034,6 @@
             "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
             "requires": {
                 "ansi-regex": "^2.0.0"
-            },
-            "dependencies": {
-                "ansi-regex": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-                }
             }
         },
         "has-flag": {
@@ -2081,9 +2074,9 @@
             }
         },
         "highlight.js": {
-            "version": "9.12.0",
-            "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.12.0.tgz",
-            "integrity": "sha1-5tnb5Xy+/mB1HwKvM2GVhwyQwB4=",
+            "version": "9.13.1",
+            "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.13.1.tgz",
+            "integrity": "sha512-Sc28JNQNDzaH6PORtRLMvif9RSn1mYuOoX3omVjnb0+HbpPygU2ALBI0R/wsiqCb4/fcp07Gdo8g+fhtFrQl6A==",
             "dev": true
         },
         "homedir-polyfill": {
@@ -2118,9 +2111,12 @@
             }
         },
         "iconv-lite": {
-            "version": "0.4.19",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-            "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+            "version": "0.4.23",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+            "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+            "requires": {
+                "safer-buffer": ">= 2.1.2 < 3"
+            }
         },
         "ignore-by-default": {
             "version": "1.0.1",
@@ -2165,15 +2161,6 @@
             "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
             "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
             "dev": true
-        },
-        "invariant": {
-            "version": "2.2.4",
-            "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-            "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-            "dev": true,
-            "requires": {
-                "loose-envify": "^1.0.0"
-            }
         },
         "invert-kv": {
             "version": "2.0.0",
@@ -2228,7 +2215,7 @@
         },
         "is-builtin-module": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+            "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
             "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
             "dev": true,
             "requires": {
@@ -2415,16 +2402,16 @@
             "dev": true
         },
         "istanbul-lib-instrument": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-2.3.2.tgz",
-            "integrity": "sha512-l7TD/VnBsIB2OJvSyxaLW/ab1+92dxZNH9wLH7uHPPioy3JZ8tnx2UXUdKmdkgmP2EFPzg64CToUP6dAS3U32Q==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.0.0.tgz",
+            "integrity": "sha512-eQY9vN9elYjdgN9Iv6NS/00bptm02EBBk70lRMaVjeA6QYocQgenVrSgC28TJurdnZa80AGO3ASdFN+w/njGiQ==",
             "dev": true,
             "requires": {
-                "@babel/generator": "7.0.0-beta.51",
-                "@babel/parser": "7.0.0-beta.51",
-                "@babel/template": "7.0.0-beta.51",
-                "@babel/traverse": "7.0.0-beta.51",
-                "@babel/types": "7.0.0-beta.51",
+                "@babel/generator": "^7.0.0",
+                "@babel/parser": "^7.0.0",
+                "@babel/template": "^7.0.0",
+                "@babel/traverse": "^7.0.0",
+                "@babel/types": "^7.0.0",
                 "istanbul-lib-coverage": "^2.0.1",
                 "semver": "^5.5.0"
             }
@@ -2466,10 +2453,10 @@
                 "yargs": "^8.0.2"
             },
             "dependencies": {
-                "ansi-regex": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                "camelcase": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+                    "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
                     "dev": true
                 },
                 "cliui": {
@@ -2506,12 +2493,6 @@
                         "shebang-command": "^1.2.0",
                         "which": "^1.2.9"
                     }
-                },
-                "decamelize": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-                    "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-                    "dev": true
                 },
                 "execa": {
                     "version": "0.7.0",
@@ -2578,6 +2559,12 @@
                         "mimic-fn": "^1.0.0"
                     }
                 },
+                "minimist": {
+                    "version": "1.2.0",
+                    "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+                    "dev": true
+                },
                 "os-locale": {
                     "version": "2.1.0",
                     "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
@@ -2587,24 +2574,6 @@
                         "execa": "^0.7.0",
                         "lcid": "^1.0.0",
                         "mem": "^1.1.0"
-                    }
-                },
-                "source-map-support": {
-                    "version": "0.4.18",
-                    "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-                    "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
-                    "dev": true,
-                    "requires": {
-                        "source-map": "^0.5.6"
-                    }
-                },
-                "strip-ansi": {
-                    "version": "3.0.1",
-                    "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "^2.0.0"
                     }
                 },
                 "ts-node": {
@@ -2684,9 +2653,9 @@
             }
         },
         "jsesc": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
-            "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+            "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
             "dev": true
         },
         "json-parse-better-errors": {
@@ -2786,15 +2755,6 @@
             "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
             "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
         },
-        "loose-envify": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-            "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-            "dev": true,
-            "requires": {
-                "js-tokens": "^3.0.0 || ^4.0.0"
-            }
-        },
         "lowercase-keys": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
@@ -2827,9 +2787,9 @@
             "dev": true
         },
         "map-age-cleaner": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.2.tgz",
-            "integrity": "sha512-UN1dNocxQq44IhJyMI4TU8phc2m9BddacHRPRjKGLYaF0jqd3xLz0jS0skpAU9WgYyoR4gHtUpzytNBS385FWQ==",
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+            "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
             "requires": {
                 "p-defer": "^1.0.0"
             }
@@ -2863,7 +2823,7 @@
         },
         "media-typer": {
             "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+            "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
             "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
         },
         "mem": {
@@ -2913,16 +2873,16 @@
             "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
         },
         "mime-db": {
-            "version": "1.36.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.36.0.tgz",
-            "integrity": "sha512-L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw=="
+            "version": "1.37.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
+            "integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg=="
         },
         "mime-types": {
-            "version": "2.1.20",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
-            "integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
+            "version": "2.1.21",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
+            "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
             "requires": {
-                "mime-db": "~1.36.0"
+                "mime-db": "~1.37.0"
             }
         },
         "mimic-fn": {
@@ -2939,10 +2899,9 @@
             }
         },
         "minimist": {
-            "version": "1.2.0",
-            "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-            "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-            "dev": true
+            "version": "0.0.10",
+            "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+            "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
         },
         "mixin-deep": {
             "version": "1.3.1",
@@ -3060,9 +3019,9 @@
             "integrity": "sha512-FiaFwKl864onHFFUV/a2szAl7X0fxVlSKNdhTf+BM8i8goEgYut8u5P9MqQqIYwvaMxjzVESsoEm/2kfkFH1rg=="
         },
         "nan": {
-            "version": "2.11.0",
-            "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.0.tgz",
-            "integrity": "sha512-F4miItu2rGnV2ySkXOQoA8FKz/SR2Q2sWP0sbTxNxz/tuokeC8WxOhPMcwi0qIyGtVn/rrSeLbvVkznqCdwYnw==",
+            "version": "2.11.1",
+            "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
+            "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
             "dev": true,
             "optional": true
         },
@@ -3101,12 +3060,12 @@
             "integrity": "sha512-OayFWziIxiHY8bCUyLX6sTpDH8Jsbp4FfYd1j1f7vZyfgkcOnAyM4oQR16f8a0s7Gl/viMGRey8eScYk4V4EZA=="
         },
         "nodemon": {
-            "version": "1.18.4",
-            "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-1.18.4.tgz",
-            "integrity": "sha512-hyK6vl65IPnky/ee+D3IWvVGgJa/m3No2/Xc/3wanS6Ce1MWjCzH6NnhPJ/vZM+6JFym16jtHx51lmCMB9HDtg==",
+            "version": "1.18.6",
+            "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-1.18.6.tgz",
+            "integrity": "sha512-4pHQNYEZun+IkIC2jCaXEhkZnfA7rQe73i8RkdRyDJls/K+WxR7IpI5uNUsAvQ0zWvYcCDNGD+XVtw2ZG86/uQ==",
             "dev": true,
             "requires": {
-                "chokidar": "^2.0.2",
+                "chokidar": "^2.0.4",
                 "debug": "^3.1.0",
                 "ignore-by-default": "^1.0.1",
                 "minimatch": "^3.0.4",
@@ -3119,9 +3078,9 @@
             },
             "dependencies": {
                 "debug": {
-                    "version": "3.2.5",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
-                    "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
+                    "version": "3.2.6",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+                    "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
                     "dev": true,
                     "requires": {
                         "ms": "^2.1.1"
@@ -3132,15 +3091,6 @@
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
                     "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
                     "dev": true
-                },
-                "supports-color": {
-                    "version": "5.5.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^3.0.0"
-                    }
                 }
             }
         },
@@ -3188,26 +3138,26 @@
             "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
         },
         "nyc": {
-            "version": "13.0.1",
-            "resolved": "https://registry.npmjs.org/nyc/-/nyc-13.0.1.tgz",
-            "integrity": "sha512-Op/bjhEF74IMtzMmgYt+ModTeMHoPZzHe4qseUguPBwg5qC6r4rYMBt1L3yRXQIbjUpEqmn24/1xAC/umQGU7w==",
+            "version": "13.1.0",
+            "resolved": "https://registry.npmjs.org/nyc/-/nyc-13.1.0.tgz",
+            "integrity": "sha512-3GyY6TpQ58z9Frpv4GMExE1SV2tAgYqC7HSy2omEhNiCT3mhT9NyiOvIE8zkbuJVFzmvvNTnE4h/7/wQae7xLg==",
             "dev": true,
             "requires": {
                 "archy": "^1.0.0",
                 "arrify": "^1.0.1",
                 "caching-transform": "^2.0.0",
-                "convert-source-map": "^1.5.1",
+                "convert-source-map": "^1.6.0",
                 "debug-log": "^1.0.1",
                 "find-cache-dir": "^2.0.0",
                 "find-up": "^3.0.0",
                 "foreground-child": "^1.5.6",
-                "glob": "^7.1.2",
+                "glob": "^7.1.3",
                 "istanbul-lib-coverage": "^2.0.1",
                 "istanbul-lib-hook": "^2.0.1",
-                "istanbul-lib-instrument": "^2.3.2",
-                "istanbul-lib-report": "^2.0.1",
+                "istanbul-lib-instrument": "^3.0.0",
+                "istanbul-lib-report": "^2.0.2",
                 "istanbul-lib-source-maps": "^2.0.1",
-                "istanbul-reports": "^2.0.0",
+                "istanbul-reports": "^2.0.1",
                 "make-dir": "^1.3.0",
                 "merge-source-map": "^1.1.0",
                 "resolve-from": "^4.0.0",
@@ -3344,9 +3294,12 @@
                     "dev": true
                 },
                 "convert-source-map": {
-                    "version": "1.5.1",
+                    "version": "1.6.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "~5.1.1"
+                    }
                 },
                 "cross-spawn": {
                     "version": "4.0.2",
@@ -3465,7 +3418,7 @@
                     "dev": true
                 },
                 "glob": {
-                    "version": "7.1.2",
+                    "version": "7.1.3",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -3584,7 +3537,7 @@
                     }
                 },
                 "istanbul-lib-report": {
-                    "version": "2.0.1",
+                    "version": "2.0.2",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -3613,7 +3566,7 @@
                     }
                 },
                 "istanbul-reports": {
-                    "version": "2.0.0",
+                    "version": "2.0.1",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -3974,6 +3927,11 @@
                     "requires": {
                         "glob": "^7.0.5"
                     }
+                },
+                "safe-buffer": {
+                    "version": "5.1.2",
+                    "bundled": true,
+                    "dev": true
                 },
                 "semver": {
                     "version": "5.5.0",
@@ -4390,13 +4348,6 @@
             "requires": {
                 "minimist": "~0.0.1",
                 "wordwrap": "~0.0.2"
-            },
-            "dependencies": {
-                "minimist": {
-                    "version": "0.0.10",
-                    "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-                    "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
-                }
             }
         },
         "os-locale": {
@@ -4421,7 +4372,7 @@
         },
         "p-is-promise": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+            "resolved": "http://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
             "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4="
         },
         "p-limit": {
@@ -4497,7 +4448,7 @@
         },
         "path-is-absolute": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
         },
         "path-is-inside": {
@@ -4571,9 +4522,9 @@
             "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
         },
         "progress": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
-            "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.1.tgz",
+            "integrity": "sha512-OE+a6vzqazc+K6LxJrX5UPyKFvGnL5CYmq2jFGNIBWHpc4QyE49/YOumcrpQFJpfejmvRtbJzgO1zPmMCqlbBg==",
             "dev": true
         },
         "proxy-addr": {
@@ -4610,9 +4561,9 @@
             }
         },
         "qs": {
-            "version": "6.5.1",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-            "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+            "version": "6.5.2",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+            "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
         },
         "range-parser": {
             "version": "1.2.0",
@@ -4620,37 +4571,14 @@
             "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
         },
         "raw-body": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
-            "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
+            "integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
             "requires": {
                 "bytes": "3.0.0",
-                "http-errors": "1.6.2",
-                "iconv-lite": "0.4.19",
+                "http-errors": "1.6.3",
+                "iconv-lite": "0.4.23",
                 "unpipe": "1.0.0"
-            },
-            "dependencies": {
-                "depd": {
-                    "version": "1.1.1",
-                    "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
-                    "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
-                },
-                "http-errors": {
-                    "version": "1.6.2",
-                    "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
-                    "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
-                    "requires": {
-                        "depd": "1.1.1",
-                        "inherits": "2.0.3",
-                        "setprototypeof": "1.0.3",
-                        "statuses": ">= 1.3.1 < 2"
-                    }
-                },
-                "setprototypeof": {
-                    "version": "1.0.3",
-                    "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
-                    "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
-                }
             }
         },
         "rc": {
@@ -4663,6 +4591,14 @@
                 "ini": "~1.3.0",
                 "minimist": "^1.2.0",
                 "strip-json-comments": "~2.0.1"
+            },
+            "dependencies": {
+                "minimist": {
+                    "version": "1.2.0",
+                    "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+                    "dev": true
+                }
             }
         },
         "read-pkg": {
@@ -4882,9 +4818,9 @@
             }
         },
         "rxjs": {
-            "version": "6.3.2",
-            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.2.tgz",
-            "integrity": "sha512-hV7criqbR0pe7EeL3O66UYVg92IR0XsA97+9y+BWTePK9SKmEI5Qd3Zj6uPnGkNzXsBywBQWTvujPl+1Kn9Zjw==",
+            "version": "6.3.3",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.3.tgz",
+            "integrity": "sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==",
             "requires": {
                 "tslib": "^1.9.0"
             }
@@ -4907,12 +4843,17 @@
         },
         "safe-regex": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+            "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
             "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
             "dev": true,
             "requires": {
                 "ret": "~0.1.10"
             }
+        },
+        "safer-buffer": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
         },
         "sax": {
             "version": "1.2.4",
@@ -4920,9 +4861,9 @@
             "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
         },
         "semver": {
-            "version": "5.5.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
-            "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw=="
+            "version": "5.6.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+            "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
         },
         "semver-diff": {
             "version": "2.1.0",
@@ -5011,9 +4952,9 @@
             "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
         },
         "shelljs": {
-            "version": "0.8.2",
-            "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.2.tgz",
-            "integrity": "sha512-pRXeNrCA2Wd9itwhvLp5LZQvPJ0wU6bcjaTMywHHGX5XWhVN2nzSu7WV0q+oUY7mGK3mgSkDDzP3MgjqdyIgbQ==",
+            "version": "0.8.3",
+            "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.3.tgz",
+            "integrity": "sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==",
             "dev": true,
             "requires": {
                 "glob": "^7.0.0",
@@ -5158,21 +5099,12 @@
             }
         },
         "source-map-support": {
-            "version": "0.5.9",
-            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
-            "integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
+            "version": "0.4.18",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+            "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
             "dev": true,
             "requires": {
-                "buffer-from": "^1.0.0",
-                "source-map": "^0.6.0"
-            },
-            "dependencies": {
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-                    "dev": true
-                }
+                "source-map": "^0.5.6"
             }
         },
         "source-map-url": {
@@ -5188,9 +5120,9 @@
             "dev": true
         },
         "spdx-correct": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
-            "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.2.tgz",
+            "integrity": "sha512-q9hedtzyXHr5S0A1vEPoK/7l8NpfkFYTq6iCY+Pno2ZbdZR6WexZFtqeVGkGxW3TEJMN914Z55EnAGMmenlIQQ==",
             "dev": true,
             "requires": {
                 "spdx-expression-parse": "^3.0.0",
@@ -5198,9 +5130,9 @@
             }
         },
         "spdx-exceptions": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
-            "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+            "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
             "dev": true
         },
         "spdx-expression-parse": {
@@ -5214,9 +5146,9 @@
             }
         },
         "spdx-license-ids": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.1.tgz",
-            "integrity": "sha512-TfOfPcYGBB5sDuPn3deByxPhmfegAhpDYKSOXZQN81Oyrrif8ZCodOLzK3AesELnCx03kikhyDwh0pfvvQvF8w==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.2.tgz",
+            "integrity": "sha512-qky9CVt0lVIECkEsYbNILVnPvycuEBkXoMFLRWsREkomQLevYhtRKC+R91a5TOAQ3bCMjikRwhyaRqj1VYatYg==",
             "dev": true
         },
         "split": {
@@ -5285,6 +5217,21 @@
             "requires": {
                 "is-fullwidth-code-point": "^2.0.0",
                 "strip-ansi": "^4.0.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "requires": {
+                        "ansi-regex": "^3.0.0"
+                    }
+                }
             }
         },
         "string_decoder": {
@@ -5296,11 +5243,11 @@
             }
         },
         "strip-ansi": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-            "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+            "version": "3.0.1",
+            "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
             "requires": {
-                "ansi-regex": "^3.0.0"
+                "ansi-regex": "^2.0.0"
             }
         },
         "strip-bom": {
@@ -5311,7 +5258,7 @@
         },
         "strip-eof": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+            "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
             "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
         },
         "strip-json-comments": {
@@ -5321,20 +5268,11 @@
             "dev": true
         },
         "supports-color": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-            "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-            "dev": true,
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
             "requires": {
-                "has-flag": "^2.0.0"
-            },
-            "dependencies": {
-                "has-flag": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-                    "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-                    "dev": true
-                }
+                "has-flag": "^3.0.0"
             }
         },
         "term-size": {
@@ -5444,9 +5382,9 @@
             }
         },
         "tree-kill": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.0.tgz",
-            "integrity": "sha512-DlX6dR0lOIRDFxI0mjL9IYg6OTncLm/Zt+JiBhE5OlFcAR8yc9S7FFXU9so0oda47frdM/JFsk7UjNt9vscKcg==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.1.tgz",
+            "integrity": "sha512-4hjqbObwlh2dLyW4tcz0Ymw0ggoaVDMveUB9w8kFSQScdRLo0gxO9J7WFcUBo+W3C1TLdFIEwNOWebgZZ0RH9Q==",
             "dev": true
         },
         "trim-right": {
@@ -5469,6 +5407,30 @@
                 "mkdirp": "^0.5.1",
                 "source-map-support": "^0.5.6",
                 "yn": "^2.0.0"
+            },
+            "dependencies": {
+                "minimist": {
+                    "version": "1.2.0",
+                    "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                },
+                "source-map-support": {
+                    "version": "0.5.9",
+                    "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
+                    "integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
+                    "dev": true,
+                    "requires": {
+                        "buffer-from": "^1.0.0",
+                        "source-map": "^0.6.0"
+                    }
+                }
             }
         },
         "tsconfig": {
@@ -5545,6 +5507,14 @@
                 "shelljs": "^0.8.2",
                 "typedoc-default-themes": "^0.5.0",
                 "typescript": "3.0.x"
+            },
+            "dependencies": {
+                "typescript": {
+                    "version": "3.0.3",
+                    "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.0.3.tgz",
+                    "integrity": "sha512-kk80vLW9iGtjMnIv11qyxLqZm20UklzuR2tL0QAnDIygIUIemcZMxlMWudl9OOt76H3ntVzcTiddQ1/pAAJMYg==",
+                    "dev": true
+                }
             }
         },
         "typedoc-default-themes": {
@@ -5554,9 +5524,9 @@
             "dev": true
         },
         "typescript": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.0.3.tgz",
-            "integrity": "sha512-kk80vLW9iGtjMnIv11qyxLqZm20UklzuR2tL0QAnDIygIUIemcZMxlMWudl9OOt76H3ntVzcTiddQ1/pAAJMYg==",
+            "version": "3.1.6",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.6.tgz",
+            "integrity": "sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==",
             "dev": true
         },
         "uglify-js": {
@@ -5794,9 +5764,9 @@
             "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
         },
         "widest-line": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.0.tgz",
-            "integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
+            "integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
             "dev": true,
             "requires": {
                 "string-width": "^2.1.1"
@@ -5816,11 +5786,6 @@
                 "strip-ansi": "^3.0.1"
             },
             "dependencies": {
-                "ansi-regex": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-                },
                 "is-fullwidth-code-point": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
@@ -5837,14 +5802,6 @@
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
                         "strip-ansi": "^3.0.0"
-                    }
-                },
-                "strip-ansi": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                    "requires": {
-                        "ansi-regex": "^2.0.0"
                     }
                 }
             }
@@ -5882,13 +5839,8 @@
         },
         "xmlbuilder": {
             "version": "9.0.7",
-            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+            "resolved": "http://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
             "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
-        },
-        "xregexp": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.0.0.tgz",
-            "integrity": "sha512-PHyM+sQouu7xspQQwELlGwwd05mXUFqwFYfqPO0cC7x4fxyHnnuetmQr6CjJiafIDoH4MogHb9dOoJzR/Y4rFg=="
         },
         "y18n": {
             "version": "4.0.0",
@@ -5902,12 +5854,12 @@
             "dev": true
         },
         "yargs": {
-            "version": "12.0.2",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.2.tgz",
-            "integrity": "sha512-e7SkEx6N6SIZ5c5H22RTZae61qtn3PYUE8JYbBFlK9sYmh3DMQ6E5ygtaG/2BW0JZi4WGgTR2IV5ChqlqrDGVQ==",
+            "version": "12.0.5",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+            "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
             "requires": {
                 "cliui": "^4.0.0",
-                "decamelize": "^2.0.0",
+                "decamelize": "^1.2.0",
                 "find-up": "^3.0.0",
                 "get-caller-file": "^1.0.1",
                 "os-locale": "^3.0.0",
@@ -5917,15 +5869,16 @@
                 "string-width": "^2.0.0",
                 "which-module": "^2.0.0",
                 "y18n": "^3.2.1 || ^4.0.0",
-                "yargs-parser": "^10.1.0"
+                "yargs-parser": "^11.1.1"
             }
         },
         "yargs-parser": {
-            "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
-            "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
+            "version": "11.1.1",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+            "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
             "requires": {
-                "camelcase": "^4.1.0"
+                "camelcase": "^5.0.0",
+                "decamelize": "^1.2.0"
             }
         },
         "yn": {

--- a/unfetter-threat-ingest/package.json
+++ b/unfetter-threat-ingest/package.json
@@ -30,7 +30,7 @@
     "dependencies": {
         "express": "^4.16.3",
         "mongoose": "^4.13.14",
-        "node-fetch": "^2.2.0",
+        "node-fetch": "2.2.0",
         "rxjs": "^6.3.2",
         "rxjs-tslint": "^0.1.5",
         "uuid": "^3.3.2",
@@ -41,7 +41,7 @@
         "@types/express": "^4.16.0",
         "@types/jasmine": "^2.8.9",
         "@types/mongoose": "^5.2.15",
-        "@types/node-fetch": "^2.1.2",
+        "@types/node-fetch": "2.1.2",
         "@types/uuid": "^3.4.4",
         "@types/xml2js": "^0.4.3",
         "@types/yargs": "^12.0.0",


### PR DESCRIPTION
Fixes unfetter-discover/unfetter#1590.

Enforces node-fetch version; otherwise, npm strangely acts as though version 2.2.0 does not exist.

- Clear out, at least, the unfetter-threat-ingest container and image.

- Run deploy-dev.yml in unfetter/ansible

- unfetter-threat-ingest should build and start properly.